### PR TITLE
Use in memory cache file instead of writing cache file to disk

### DIFF
--- a/pytoyoda/controller.py
+++ b/pytoyoda/controller.py
@@ -56,7 +56,7 @@ class Controller:
             self._token = cache_data["access_token"]
             self._refresh_token = cache_data["refresh_token"]
             self._uuid = cache_data["uuid"]
-            self._token_expiration = datetime.fromisoformat(cache_data["expiration"])
+            self._token_expiration = cache_data["expiration"]
 
     async def login(self) -> None:
         """Perform first login."""

--- a/simple_client_example.py
+++ b/simple_client_example.py
@@ -90,6 +90,8 @@ async def get_information():
         pp.pprint(f"Notifications: {[[x] for x in car.notifications]}")
         # Service history
         pp.pprint(f"Latest service: {car.get_latest_service_history()}")
+        # Last trip distance
+        pp.pprint(f"Last trip distance: {car.last_trip.distance}")
         # Summary
         # pp.pprint(
         #    f"Summary: {[[x] for x in await car.get_summary(date.today() - timedelta(days=7), date.today(), summary_type=SummaryType.DAILY)]}"  # noqa: E501 # pylint: disable=C0301

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -6,6 +6,11 @@ import pytest
 
 from pytoyoda.controller import _TOKEN_CACHE
 
+TEST_USER = "user@email.info"
+TEST_PASSWORD = "password"
+TEST_TOKEN = "eyJ0eXAiOiJKV1QiLCJraWQiOiJZeVZ2SEU5d0xKNDBWVEpyc3pBNDJ6eTNyWjg9IiwiYWxnIjoiUlMyNTYifQ"  # noqa: E501
+TEST_UUID = "12345678-1234-1234-1234-123456789012"
+
 
 @pytest.fixture(scope="module")
 def data_folder(request) -> str:

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from pytoyoda.controller import CACHE_FILENAME
+from pytoyoda.controller import _TOKEN_CACHE
 
 
 @pytest.fixture(scope="module")
@@ -17,4 +17,4 @@ def data_folder(request) -> str:
 def remove_cache() -> None:
     """Remove the credentials cache file if it exists."""
     # Remove cache file if exists
-    Path.unlink(CACHE_FILENAME, missing_ok=True)
+    _TOKEN_CACHE.clear()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -15,6 +15,5 @@ def data_folder(request) -> str:
 
 @pytest.fixture(scope="function")
 def remove_cache() -> None:
-    """Remove the credentials cache file if it exists."""
-    # Remove cache file if exists
+    """Remove the credentials cache if it exists."""
     _TOKEN_CACHE.clear()

--- a/tests/integration_tests/data/cached_token.json
+++ b/tests/integration_tests/data/cached_token.json
@@ -1,7 +1,0 @@
-{
-  "access_token": "eyJ0eXAiOiJKV1QiLCJraWQiOiJZeVZ2SEU5d0xKNDBWVEpyc3pBNDJ6eTNyWjg9IiwiYWxnIjoiUlMyNTYifQ",
-  "refresh_token": "eyJ0eXAiOiJKV1QiLCJraWQiOiJZeVZ2SEU5d0xKNDBWVEpyc3pBNDJ6eTNyWjg9IiwiYWxnIjoiUlMyNTYifQ",
-  "uuid": "12345678-1234-1234-1234-123456789012",
-  "expiration": "2024-01-01 16:20:20.316881",
-  "username": "user@email.info"
-}

--- a/tests/integration_tests/test_authentication.py
+++ b/tests/integration_tests/test_authentication.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
+from conftest import TEST_PASSWORD, TEST_TOKEN, TEST_USER, TEST_UUID
 from pytest_httpx import HTTPXMock
 
 from pytoyoda import MyT
@@ -46,7 +47,7 @@ def build_routes(httpx_mock: HTTPXMock, filenames: List[str]) -> None:  # noqa: 
 async def test_authenticate(httpx_mock):  # noqa: D103
     build_routes(httpx_mock, ["authenticate_working.json"])
 
-    client = MyT("user@email.com", "password")
+    client = MyT(TEST_USER, TEST_PASSWORD)
     # Nothing validates this is correct,
     # just replays a "correct" authentication sequence
     await client.login()
@@ -57,7 +58,7 @@ async def test_authenticate(httpx_mock):  # noqa: D103
 async def test_authenticate_invalid_username(httpx_mock: HTTPXMock):  # noqa: D103
     build_routes(httpx_mock, ["authenticate_invalid_username.json"])
 
-    client = MyT("user@email.com", "password")
+    client = MyT(TEST_USER, TEST_PASSWORD)
     # Nothing validates this is correct,
     # just replays an invalid username authentication sequence
     with pytest.raises(ToyotaInvalidUsernameError):
@@ -69,7 +70,7 @@ async def test_authenticate_invalid_username(httpx_mock: HTTPXMock):  # noqa: D1
 async def test_authenticate_invalid_password(httpx_mock: HTTPXMock):  # noqa: D103
     build_routes(httpx_mock, ["authenticate_invalid_password.json"])
 
-    client = MyT("user@email.com", "password")
+    client = MyT(TEST_USER, TEST_PASSWORD)
     # Nothing validates this is correct,
     # just replays an invalid username authentication sequence
     with pytest.raises(ToyotaLoginError):
@@ -77,46 +78,38 @@ async def test_authenticate_invalid_password(httpx_mock: HTTPXMock):  # noqa: D1
 
 
 @pytest.mark.asyncio
-async def test_authenticate_refresh_token(data_folder, httpx_mock: HTTPXMock):  # noqa: D103
-    # Ensure expired cache file.
-    with open(f"{data_folder}/cached_token.json", encoding="utf-8") as f:  # noqa: ASYNC230
-        cached_token = json.load(f)
-
-        username = "user@email.info"
-        _TOKEN_CACHE[username] = {
-            "access_token": cached_token["access_token"],
-            "refresh_token": cached_token["refresh_token"],
-            "uuid": cached_token["uuid"],
-            "expiration": cached_token["expiration"],
-        }
+async def test_authenticate_refresh_token(httpx_mock: HTTPXMock):  # noqa: D103
+    _TOKEN_CACHE[TEST_USER] = {
+        "access_token": TEST_TOKEN,
+        "refresh_token": TEST_TOKEN,
+        "uuid": TEST_UUID,
+        "expiration": datetime(
+            2024, 1, 1, 16, 20, 20, 316881
+        ),  # expired expiration datetime
+    }
 
     build_routes(httpx_mock, ["authenticate_refresh_token.json"])
 
-    client = MyT("user@email.info", "password")
+    client = MyT(TEST_USER, TEST_PASSWORD)
     # Nothing validates this is correct,
     # just replays a refresh token sequence
     await client.login()
 
 
 @pytest.mark.asyncio
-async def test_get_static_data(data_folder, httpx_mock: HTTPXMock):  # noqa: D103
+async def test_get_static_data(httpx_mock: HTTPXMock):  # noqa: D103
     #  Create valid token => Means no authentication requests
-    with open(f"{data_folder}/cached_token.json", encoding="utf-8") as f:  # noqa: ASYNC230
-        cached_token = json.load(f)
-        cached_token["expiration"] = datetime.now() + timedelta(hours=4)
-
-        username = "user@email.info"
-        _TOKEN_CACHE[username] = {
-            "access_token": cached_token["access_token"],
-            "refresh_token": cached_token["refresh_token"],
-            "uuid": cached_token["uuid"],
-            "expiration": cached_token["expiration"],
-        }
+    _TOKEN_CACHE[TEST_USER] = {
+        "access_token": TEST_TOKEN,
+        "refresh_token": TEST_TOKEN,
+        "uuid": TEST_UUID,
+        "expiration": datetime.now() + timedelta(hours=4),  # valid expiration datetime
+    }
 
     # Ensure expired cache file.
     build_routes(httpx_mock, ["get_static_data.json"])
 
-    client = MyT("user@email.info", "password")
+    client = MyT(TEST_USER, TEST_PASSWORD)
     # Nothing validates this is correct,
     # just replays a refresh token sequence
     await client.login()


### PR DESCRIPTION
Writing the cache file to disk always caused problems in connection with the async functionalities, or if the process was executed by a user who had insufficient write permissions (Se also: https://github.com/pytoyoda/ha_toyota/issues/8).
With this PR we use an in memory cache and avoid IO operations.