### PR TITLE
fixup servicing_dealer if not part of the payload

### DIFF
--- a/pytoyoda/models/endpoints/service_history.py
+++ b/pytoyoda/models/endpoints/service_history.py
@@ -37,7 +37,7 @@ class ServiceHistoryModel(CustomEndpointBaseModel):
     service_date: Optional[date] = Field(alias="serviceDate")
     service_history_id: Optional[str] = Field(alias="serviceHistoryId")
     service_provider: Optional[str] = Field(alias="serviceProvider")
-    servicing_dealer: Any = Field(alias="servicingDealer")
+    servicing_dealer: Any = Field(alias="servicingDealer", default=None)
     unit: Optional[str] = None
 
 


### PR DESCRIPTION

here an example of the raw payload reported by toyota endpoint

```
{'payload': {'serviceHistories': [{'serviceDate': '2024-07-18', 'mileage': '24340', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': 'PROVIDER', 'notes': None, 'serviceHistoryId': '123', 'serviceCategory': 'HSC', 'customerCreatedRecord': False}, {'serviceDate': '2022-12-02', 'mileage': '13263', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': 'PROVIDER', 'notes': None, 'serviceHistoryId': '456', 'serviceCategory': 'HSC', 'customerCreatedRecord': False}, {'serviceDate': '2021-04-07', 'mileage': '7', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '789', 'serviceCategory': 'ACC', 'customerCreatedRecord': False}, {'serviceDate': '2021-03-24', 'mileage': '0', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '1121314', 'serviceCategory': 'VDE', 'customerCreatedRecord': False}, {'serviceDate': '2021-02-10', 'mileage': '0', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '151617', 'serviceCategory': 'ACC', 'customerCreatedRecord': False}, {'serviceDate': '2021-02-10', 'mileage': '0', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '18920', 'serviceCategory': 'ACC', 'customerCreatedRecord': False}, {'serviceDate': '2021-02-10', 'mileage': '0', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '21', 'serviceCategory': 'ACC', 'customerCreatedRecord': False}, {'serviceDate': '2021-02-10', 'mileage': '0', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '2324', 'serviceCategory': 'ACC', 'customerCreatedRecord': False}, {'serviceDate': '2021-01-15', 'mileage': '0', 'unit': 'km', 'roNumber': None, 'operationsPerformed': None, 'serviceProvider': '', 'notes': None, 'serviceHistoryId': '2526', 'serviceCategory': 'ACC', 'customerCreatedRecord': False}]}}
```