### PR TITLE
add headers to enable the library to work again

### DIFF
--- a/pytoyoda/controller.py
+++ b/pytoyoda/controller.py
@@ -384,6 +384,8 @@ class Controller:
             "x-guid": self._uuid,
             "guid": self._uuid,
             "authorization": f"Bearer {self._token}",
+            "x-appversion": "2.13.0",
+            "x-client-ref": "27ad3073009f94daf6b4550dcc886e82cf863393c43494950d37b71b95b1057d",
             "x-channel": "ONEAPP",
             "x-brand": "T",
             "user-agent": "okhttp/4.10.0",

--- a/pytoyoda/controller.py
+++ b/pytoyoda/controller.py
@@ -385,7 +385,7 @@ class Controller:
             "guid": self._uuid,
             "authorization": f"Bearer {self._token}",
             "x-appversion": "2.13.0",
-            "x-client-ref": "27ad3073009f94daf6b4550dcc886e82cf863393c43494950d37b71b95b1057d",
+            "x-client-ref": "27ad3073009f94daf6b4550dcc886e82cf863393c43494950d37b71b95b1057d",  # noqa: E501
             "x-channel": "ONEAPP",
             "x-brand": "T",
             "user-agent": "okhttp/4.10.0",


### PR DESCRIPTION
Fixes #84 

Header `"x-appversion": "2.13.0",` resolves the _500_ response.
