### PR TITLE
Avoid AttributeError for ClimateStatus

### DIFF
--- a/pytoyoda/models/climate.py
+++ b/pytoyoda/models/climate.py
@@ -77,7 +77,7 @@ class ClimateStatus(CustomAPIBaseModel[ClimateStatusModel]):
             str: The type
 
         """
-        return self._data.type
+        return self._data.type if self._data else None
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/pytoyoda/models/climate.py
+++ b/pytoyoda/models/climate.py
@@ -70,11 +70,11 @@ class ClimateStatus(CustomAPIBaseModel[ClimateStatusModel]):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def type(self) -> str:
+    def type(self) -> Optional[str]:
         """The type.
 
         Returns:
-            str: The type
+            Optional[str]: The type, or None if unavailable
 
         """
         return self._data.type if self._data else None


### PR DESCRIPTION
Hopefully fixes this error message in HASS logs:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/logging/handlers.py", line 1509, in emit
    self.enqueue(self.prepare(record))
                 ~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/handlers.py", line 1491, in prepare
    msg = self.format(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 998, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 711, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 398, in getMessage
    msg = str(self.msg)
  File "/usr/local/lib/python3.13/site-packages/pytoyoda/utils/models.py", line 89, in __repr__
    f"{k}={getattr(self, k)!s}"
          ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pydantic/main.py", line 1243, in __str__
    return self.__repr_str__(' ')
           ~~~~~~~~~~~~~~~~~^^^^^
  File "/usr/local/lib/python3.13/site-packages/pydantic/_internal/_repr.py", line 63, in __repr_str__
    return join_str.join(repr(v) if a is None else f'{a}={v!r}' for a, v in self.__repr_args__())
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pydantic/_internal/_repr.py", line 63, in <genexpr>
    return join_str.join(repr(v) if a is None else f'{a}={v!r}' for a, v in self.__repr_args__())
                                                                            ~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/pydantic/main.py", line 1212, in __repr_args__
    (k, getattr(self, k)) for k, v in self.__pydantic_computed_fields__.items() if v.repr
        ~~~~~~~^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pydantic/main.py", line 991, in __getattr__
    return super().__getattribute__(item)  # Raises AttributeError if appropriate
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pytoyoda/models/climate.py", line 80, in type
    return self._data.type
           ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'type'
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2034, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 268, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 380, in _async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 281, in _async_update_data
    return await self.update_method()
  File "/config/custom_components/toyota/__init__.py", line 143, in async_get_vehicle_data
    _LOGGER.debug(vehicle_informations)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1507, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1664, in _log
    self.handle(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1680, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1736, in callHandlers
    hdlr.handle(record)
  File "/usr/src/homeassistant/homeassistant/util/logging.py", line 113, in handle
    self.emit(record)
Unable to print the message and arguments - possible formatting error.
Use the traceback above to help find the error.
```