### PR TITLE
New feature: Adding specific properties for scores in order to be used in ha_toyota

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# MacOS
+.DS_Store
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/pytoyoda/pytoyoda"
 "Release Notes" = "https://github.com/pytoyoda/pytoyoda/releases"
 
 [tool.poetry]
-version = "0.0.0"
+version = "4.0.2"
 packages = [
     { include = "pytoyoda" },
 ]

--- a/pytoyoda/models/trips.py
+++ b/pytoyoda/models/trips.py
@@ -212,7 +212,6 @@ class Trip(CustomAPIBaseModel[type[T]]):
 
         return 0.0
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
     def score(self) -> float:
         """The (hybrid) score for the trip.
@@ -224,7 +223,59 @@ class Trip(CustomAPIBaseModel[type[T]]):
         if self._trip.scores and self._trip.scores.global_:
             return self._trip.scores.global_
 
-        return 0.0
+        return 0
+
+    @property
+    def score_acceleration(self) -> float:
+        """The (hybrid) acceleration score for the trip.
+
+        Returns:
+            float: The hybrid acceleration score for the trip
+
+        """
+        if self._trip.scores and self._trip.scores.acceleration:
+            return self._trip.scores.acceleration
+
+        return 0
+
+    @property
+    def score_braking(self) -> float:
+        """The (hybrid) braking score for the trip.
+
+        Returns:
+            float: The hybrid braking score for the trip
+
+        """
+        if self._trip.scores and self._trip.scores.braking:
+            return self._trip.scores.braking
+
+        return 0
+
+    @property
+    def score_advice(self) -> float:
+        """The (hybrid) advice score for the trip.
+
+        Returns:
+            float: The hybrid advice score for the trip
+
+        """
+        if self._trip.scores and self._trip.scores.advice:
+            return self._trip.scores.advice
+
+        return 0
+
+    @property
+    def score_constant_speed(self) -> float:
+        """The (hybrid) constant speed score for the trip.
+
+        Returns:
+            float: The hybrid constant speed score for the trip
+
+        """
+        if self._trip.scores and self._trip.scores.constant_speed:
+            return self._trip.scores.constant_speed
+
+        return 0
 
     @computed_field  # type: ignore[prop-decorator]
     @property


### PR DESCRIPTION
Must be merged before the corresponding PR in ha_toyota. That will add the scores for the last trip as a sensor (global score as global value and sub-scores as properties). Global score, acceleration score, braking score, advice score and constant speed score.

(All checks passed here.)