### PR TITLE
Add support for BEV climate endpoint

### DIFF
--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -192,34 +192,23 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                 ),
                 EndpointDefinition(
                     name="climate_settings",
-                    capable=any(
-                        (
+                    capable=(
+                        getattr(
+                            getattr(self._vehicle_info, "features", False),
+                            "climate_start_engine",
+                            False,
+                        )
+                        or any(
                             getattr(
-                                getattr(self._vehicle_info, "features", False),
-                                "climate_start_engine",
+                                getattr(self._vehicle_info, "extended_capabilities", False),
+                                attr,
                                 False,
-                            ),
-                            getattr(
-                                getattr(
-                                    self._vehicle_info, "extended_capabilities", False
-                                ),
+                            )
+                            for attr in (
                                 "climate_capable",
-                                False,
-                            ),
-                            getattr(
-                                getattr(
-                                    self._vehicle_info, "extended_capabilities", False
-                                ),
                                 "econnect_climate_capable",
-                                False,
-                            ),
-                            getattr(
-                                getattr(
-                                    self._vehicle_info, "extended_capabilities", False
-                                ),
                                 "remote_engine_start_stop",
-                                False,
-                            ),
+                            )
                         )
                     ),
                     function=partial(

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -200,7 +200,9 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                         )
                         or any(
                             getattr(
-                                getattr(self._vehicle_info, "extended_capabilities", False),
+                                getattr(
+                                    self._vehicle_info, "extended_capabilities", False
+                                ),
                                 attr,
                                 False,
                             )

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -192,10 +192,35 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                 ),
                 EndpointDefinition(
                     name="climate_settings",
-                    capable=getattr(
-                        getattr(self._vehicle_info, "features", False),
-                        "climate_start_engine",
-                        False,
+                    capable=any(
+                        (
+                            getattr(
+                                getattr(self._vehicle_info, "features", False),
+                                "climate_start_engine",
+                                False,
+                            ),
+                            getattr(
+                                getattr(
+                                    self._vehicle_info, "extended_capabilities", False
+                                ),
+                                "climate_capable",
+                                False,
+                            ),
+                            getattr(
+                                getattr(
+                                    self._vehicle_info, "extended_capabilities", False
+                                ),
+                                "econnect_climate_capable",
+                                False,
+                            ),
+                            getattr(
+                                getattr(
+                                    self._vehicle_info, "extended_capabilities", False
+                                ),
+                                "remote_engine_start_stop",
+                                False,
+                            ),
+                        )
                     ),
                     function=partial(
                         self._api.get_climate_settings, vin=self._vehicle_info.vin


### PR DESCRIPTION
Different car models handle climate controls differently. At least BEV includes `climate_capable` in extended capabilities, not as an option in features. See [HA_Toyota issue 246](https://github.com/pytoyoda/ha_toyota/issues/246) for a discussion.

This PR at least works for my BEV (BZ4X 2024)