### PR TITLE
fix: swallow ToyotaApiError per-endpoint in Vehicle.update()

### DIFF
--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -268,7 +268,8 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             ]
         )
         for name, data in await responses:
-            self._endpoint_data[name] = data
+            if data is not None:
+                self._endpoint_data[name] = data
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -254,7 +254,11 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         async def parallel_wrapper(
             name: str, function: partial
         ) -> tuple[str, dict[str, Any]]:
-            r = await function()
+            try:
+                r = await function()
+            except ToyotaApiError as e:
+                logger.warning(f"Failed to fetch '{name}': {e}")
+                r = None
             return name, r
 
         responses = asyncio.gather(

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -17,7 +17,7 @@ from loguru import logger
 from pydantic import computed_field
 
 from pytoyoda.api import Api
-from pytoyoda.exceptions import ToyotaApiError
+from pytoyoda.exceptions import ToyotaApiError, ToyotaInternalError
 from pytoyoda.models.climate import ClimateSettings, ClimateStatus
 from pytoyoda.models.dashboard import Dashboard
 from pytoyoda.models.electric_status import ElectricStatus
@@ -256,7 +256,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         ) -> tuple[str, dict[str, Any]]:
             try:
                 r = await function()
-            except ToyotaApiError as e:
+            except (ToyotaApiError, ToyotaInternalError) as e:
                 logger.warning(f"Failed to fetch '{name}': {e}")
                 r = None
             return name, r


### PR DESCRIPTION
When an endpoint (e.g. get_climate_status) returns a 500 from the Toyota API, log a warning and store None for that endpoint instead of propagating the exception through asyncio.gather and crashing the entire update() call.

The code is written using Claude, as I am not a Python developer, but the change is simple and fixes the error for me, after testing with sandbox/simple_client_example.py

Should fix: https://github.com/pytoyoda/ha_toyota/issues/255