### PR TITLE
fix: handle partial summary payloads from Toyota /v1/trips

### DIFF
--- a/pytoyoda/models/endpoints/trips.py
+++ b/pytoyoda/models/endpoints/trips.py
@@ -14,16 +14,22 @@ from pytoyoda.utils.models import CustomEndpointBaseModel
 
 
 class _SummaryBaseModel(CustomEndpointBaseModel):
-    length: int | None
-    duration: int | None
-    duration_idle: int | None = Field(alias="durationIdle")
-    countries: list[str] | None
-    max_speed: float | None = Field(alias="maxSpeed")
-    average_speed: float | None = Field(alias="averageSpeed")
-    length_overspeed: int | None = Field(alias="lengthOverspeed")
-    duration_overspeed: int | None = Field(alias="durationOverspeed")
-    length_highway: int | None = Field(alias="lengthHighway")
-    duration_highway: int | None = Field(alias="durationHighway")
+    # Every field is optional. The Toyota /v1/trips endpoint currently returns
+    # only {length, duration, averageSpeed, fuelConsumption} at the histogram
+    # summary level; the rest (durationIdle, countries, min/max speed,
+    # overspeed/highway breakdowns) are not present in the payload. Without
+    # defaults here, the CustomEndpointBaseModel wrapper silently converts the
+    # whole summary to None on every field it can't fill, masking real data.
+    length: int | None = None
+    duration: int | None = None
+    duration_idle: int | None = Field(alias="durationIdle", default=None)
+    countries: list[str] | None = None
+    max_speed: float | None = Field(alias="maxSpeed", default=None)
+    average_speed: float | None = Field(alias="averageSpeed", default=None)
+    length_overspeed: int | None = Field(alias="lengthOverspeed", default=None)
+    duration_overspeed: int | None = Field(alias="durationOverspeed", default=None)
+    length_highway: int | None = Field(alias="lengthHighway", default=None)
+    duration_highway: int | None = Field(alias="durationHighway", default=None)
     fuel_consumption: float | None = Field(
         alias="fuelConsumption", default=None
     )  # Electric cars might not use fuel. Milliliters.

--- a/pytoyoda/models/endpoints/trips.py
+++ b/pytoyoda/models/endpoints/trips.py
@@ -37,23 +37,45 @@ class _SummaryBaseModel(CustomEndpointBaseModel):
     def __add__(self, other: _SummaryBaseModel) -> _SummaryBaseModel:
         """Add together two SummaryBaseModel's.
 
-        Handles Min/Max/Average fields correctly.
+        Handles Min/Max/Average fields correctly. Every numeric field is declared
+        ``int | None`` / ``float | None``, so either operand may be ``None`` on any
+        given day. Use ``add_with_none`` throughout and guard list/max/avg ops so
+        a single missing day doesn't crash the whole weekly summary.
 
         Args:
             other (_SummaryBaseModel): to be added
 
         """
         if other is not None:
-            self.length += other.length
-            self.duration += other.duration
-            self.duration_idle += other.duration_idle
-            self.countries.extend(x for x in other.countries if x not in self.countries)
-            self.max_speed = max(self.max_speed, other.max_speed)
-            self.average_speed = (self.average_speed + other.average_speed) / 2.0
-            self.length_overspeed += other.length_overspeed
-            self.duration_overspeed += other.duration_overspeed
-            self.length_highway += other.length_highway
-            self.duration_highway += other.duration_highway
+            self.length = add_with_none(self.length, other.length)
+            self.duration = add_with_none(self.duration, other.duration)
+            self.duration_idle = add_with_none(self.duration_idle, other.duration_idle)
+            if other.countries:
+                if self.countries is None:
+                    self.countries = []
+                self.countries.extend(
+                    x for x in other.countries if x not in self.countries
+                )
+            if self.max_speed is None:
+                self.max_speed = other.max_speed
+            elif other.max_speed is not None:
+                self.max_speed = max(self.max_speed, other.max_speed)
+            if self.average_speed is None:
+                self.average_speed = other.average_speed
+            elif other.average_speed is not None:
+                self.average_speed = (self.average_speed + other.average_speed) / 2.0
+            self.length_overspeed = add_with_none(
+                self.length_overspeed, other.length_overspeed
+            )
+            self.duration_overspeed = add_with_none(
+                self.duration_overspeed, other.duration_overspeed
+            )
+            self.length_highway = add_with_none(
+                self.length_highway, other.length_highway
+            )
+            self.duration_highway = add_with_none(
+                self.duration_highway, other.duration_highway
+            )
             self.fuel_consumption = add_with_none(
                 self.fuel_consumption, other.fuel_consumption
             )

--- a/pytoyoda/models/endpoints/trips.py
+++ b/pytoyoda/models/endpoints/trips.py
@@ -37,50 +37,52 @@ class _SummaryBaseModel(CustomEndpointBaseModel):
     def __add__(self, other: _SummaryBaseModel) -> _SummaryBaseModel:
         """Add together two SummaryBaseModel's.
 
-        Handles Min/Max/Average fields correctly. Every numeric field is declared
-        ``int | None`` / ``float | None``, so either operand may be ``None`` on any
-        given day. Use ``add_with_none`` throughout and guard list/max/avg ops so
-        a single missing day doesn't crash the whole weekly summary.
+        Returns a new instance rather than mutating ``self`` (Python convention
+        for ``__add__`` vs ``__iadd__``). Every numeric field is declared
+        ``int | None`` / ``float | None``, so either operand may be ``None`` on
+        any given day. Use ``add_with_none`` throughout and guard list/max/avg
+        ops so a single missing day doesn't crash the whole weekly summary.
 
         Args:
             other (_SummaryBaseModel): to be added
 
         """
-        if other is not None:
-            self.length = add_with_none(self.length, other.length)
-            self.duration = add_with_none(self.duration, other.duration)
-            self.duration_idle = add_with_none(self.duration_idle, other.duration_idle)
-            if other.countries:
-                if self.countries is None:
-                    self.countries = []
-                self.countries.extend(
-                    x for x in other.countries if x not in self.countries
-                )
-            if self.max_speed is None:
-                self.max_speed = other.max_speed
-            elif other.max_speed is not None:
-                self.max_speed = max(self.max_speed, other.max_speed)
-            if self.average_speed is None:
-                self.average_speed = other.average_speed
-            elif other.average_speed is not None:
-                self.average_speed = (self.average_speed + other.average_speed) / 2.0
-            self.length_overspeed = add_with_none(
-                self.length_overspeed, other.length_overspeed
+        result = self.model_copy(deep=True)
+        if other is None:
+            return result
+        result.length = add_with_none(result.length, other.length)
+        result.duration = add_with_none(result.duration, other.duration)
+        result.duration_idle = add_with_none(result.duration_idle, other.duration_idle)
+        if other.countries:
+            if result.countries is None:
+                result.countries = []
+            result.countries.extend(
+                x for x in other.countries if x not in result.countries
             )
-            self.duration_overspeed = add_with_none(
-                self.duration_overspeed, other.duration_overspeed
-            )
-            self.length_highway = add_with_none(
-                self.length_highway, other.length_highway
-            )
-            self.duration_highway = add_with_none(
-                self.duration_highway, other.duration_highway
-            )
-            self.fuel_consumption = add_with_none(
-                self.fuel_consumption, other.fuel_consumption
-            )
-
-        return self
+        if result.max_speed is None:
+            result.max_speed = other.max_speed
+        elif other.max_speed is not None:
+            result.max_speed = max(result.max_speed, other.max_speed)
+        if result.average_speed is None:
+            result.average_speed = other.average_speed
+        elif other.average_speed is not None:
+            result.average_speed = (result.average_speed + other.average_speed) / 2.0
+        result.length_overspeed = add_with_none(
+            result.length_overspeed, other.length_overspeed
+        )
+        result.duration_overspeed = add_with_none(
+            result.duration_overspeed, other.duration_overspeed
+        )
+        result.length_highway = add_with_none(
+            result.length_highway, other.length_highway
+        )
+        result.duration_highway = add_with_none(
+            result.duration_highway, other.duration_highway
+        )
+        result.fuel_consumption = add_with_none(
+            result.fuel_consumption, other.fuel_consumption
+        )
+        return result
 
 
 class _SummaryModel(_SummaryBaseModel):
@@ -128,23 +130,24 @@ class _HDCModel(CustomEndpointBaseModel):
     def __add__(self, other: _HDCModel) -> _HDCModel:
         """Add together two HDCModel's.
 
-        Handles Min/Max/Average fields correctly.
+        Returns a new instance rather than mutating ``self``.
 
         Args:
-            other (_SummaryBaseModel): to be added
+            other (_HDCModel): to be added
 
         """
-        if other is not None:
-            self.ev_time = add_with_none(self.ev_time, other.ev_time)
-            self.ev_distance = add_with_none(self.ev_distance, other.ev_distance)
-            self.charge_time = add_with_none(self.charge_time, other.charge_time)
-            self.charge_dist = add_with_none(self.charge_dist, other.charge_dist)
-            self.eco_time = add_with_none(self.eco_time, other.eco_time)
-            self.eco_dist = add_with_none(self.eco_dist, other.eco_dist)
-            self.power_time = add_with_none(self.power_time, other.power_time)
-            self.power_dist = add_with_none(self.power_dist, other.power_dist)
-
-        return self
+        result = self.model_copy(deep=True)
+        if other is None:
+            return result
+        result.ev_time = add_with_none(result.ev_time, other.ev_time)
+        result.ev_distance = add_with_none(result.ev_distance, other.ev_distance)
+        result.charge_time = add_with_none(result.charge_time, other.charge_time)
+        result.charge_dist = add_with_none(result.charge_dist, other.charge_dist)
+        result.eco_time = add_with_none(result.eco_time, other.eco_time)
+        result.eco_dist = add_with_none(result.eco_dist, other.eco_dist)
+        result.power_time = add_with_none(result.power_time, other.power_time)
+        result.power_dist = add_with_none(result.power_dist, other.power_dist)
+        return result
 
 
 class _RouteModel(CustomEndpointBaseModel):

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -778,7 +778,10 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             )
 
             for histogram in week_histograms[1:]:
-                add_with_none(build_hdc, histogram.hdc)
+                # ``add_with_none`` returns the sum, so we must capture it;
+                # without the assignment ``build_hdc`` would stay at the
+                # first histogram's hdc (or ``None`` if that was None).
+                build_hdc = add_with_none(build_hdc, histogram.hdc)
                 # histogram.summary (and the seed build_summary) may be None on
                 # days where the Toyota API returned a partial payload. Seed with
                 # the first non-None summary we see, then accumulate.
@@ -859,7 +862,9 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                 summary[1:], [*summary[2:], None], strict=False
             ):
                 summary_month = date(day=1, month=month.month, year=month.year)
-                add_with_none(build_hdc, month.hdc)
+                # ``add_with_none`` returns the sum; capture it or ``build_hdc``
+                # stays at the year's first month's hdc.
+                build_hdc = add_with_none(build_hdc, month.hdc)
                 # month.summary (and the seed build_summary) may be None when
                 # the Toyota API returned partial data.
                 if month.summary is not None:

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -739,6 +739,8 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         self, summary: list[_SummaryItemModel]
     ) -> list[Summary]:
         summary.sort(key=attrgetter("year", "month"))
+        # Skip histograms with summary=None - a hollow Summary crashes
+        # downstream when sensors read its properties (see #278).
         return [
             Summary(
                 histogram.summary,
@@ -749,6 +751,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             )
             for month in summary
             for histogram in sorted(month.histograms, key=attrgetter("day"))
+            if histogram.summary is not None
         ]
 
     def _generate_weekly_summaries(
@@ -776,13 +779,25 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
 
             for histogram in week_histograms[1:]:
                 add_with_none(build_hdc, histogram.hdc)
-                build_summary += histogram.summary
+                # histogram.summary (and the seed build_summary) may be None on
+                # days where the Toyota API returned a partial payload. Seed with
+                # the first non-None summary we see, then accumulate.
+                if histogram.summary is None:
+                    continue
+                if build_summary is None:
+                    build_summary = copy.copy(histogram.summary)
+                else:
+                    build_summary += histogram.summary
 
             end_date = Arrow(
                 week_histograms[-1].year,
                 week_histograms[-1].month,
                 week_histograms[-1].day,
             )
+            # Skip weeks where every histogram.summary was None - a hollow
+            # Summary crashes downstream when sensors read its properties.
+            if build_summary is None:
+                continue
             ret.append(
                 Summary(
                     build_summary,
@@ -802,6 +817,10 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         ret: list[Summary] = []
         summary.sort(key=attrgetter("year", "month"))
         for month in summary:
+            # Skip months with summary=None - a hollow Summary crashes
+            # downstream when sensors read its properties (see #278).
+            if month.summary is None:
+                continue
             month_start = Arrow(month.year, month.month, 1).date()
             month_end = (
                 Arrow(month.year, month.month, 1).shift(months=1).shift(days=-1).date()
@@ -831,26 +850,40 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         start_date = date(day=1, month=summary[0].month, year=summary[0].year)
 
         if len(summary) == 1:
-            ret.append(
-                Summary(build_summary, self._metric, start_date, to_date, build_hdc)
-            )
+            if build_summary is not None:
+                ret.append(
+                    Summary(build_summary, self._metric, start_date, to_date, build_hdc)
+                )
         else:
             for month, next_month in zip(
                 summary[1:], [*summary[2:], None], strict=False
             ):
                 summary_month = date(day=1, month=month.month, year=month.year)
                 add_with_none(build_hdc, month.hdc)
-                build_summary += month.summary
+                # month.summary (and the seed build_summary) may be None when
+                # the Toyota API returned partial data.
+                if month.summary is not None:
+                    if build_summary is None:
+                        build_summary = copy.copy(month.summary)
+                    else:
+                        build_summary += month.summary
 
                 if next_month is None or next_month.year != month.year:
                     end_date = min(
                         to_date, date(day=31, month=12, year=summary_month.year)
                     )
-                    ret.append(
-                        Summary(
-                            build_summary, self._metric, start_date, end_date, build_hdc
+                    # Skip years where every month.summary was None - a hollow
+                    # Summary crashes downstream when sensors read its properties.
+                    if build_summary is not None:
+                        ret.append(
+                            Summary(
+                                build_summary,
+                                self._metric,
+                                start_date,
+                                end_date,
+                                build_hdc,
+                            )
                         )
-                    )
                     if next_month:
                         start_date = date(
                             day=1, month=next_month.month, year=next_month.year

--- a/tests/unit_tests/test_models/test_trips.py
+++ b/tests/unit_tests/test_models/test_trips.py
@@ -90,6 +90,29 @@ def test_summary_base_model_add_handles_both_none() -> None:
 
 
 def test_summary_base_model_add_noop_when_other_is_none() -> None:
-    """Adding None returns self unchanged (predates this fix, kept as a guard)."""
+    """Adding None returns a copy with the same values and no side effects."""
     summary = _SummaryBaseModel.model_validate({"length": 42})
-    assert (summary + None).length == 42
+    result = summary + None
+    assert result.length == 42
+    assert result is not summary
+
+
+def test_summary_base_model_add_does_not_mutate_operands() -> None:
+    """``__add__`` must return a new instance; operands must be untouched.
+
+    Python convention: ``a + b`` leaves ``a`` and ``b`` alone. In-place
+    mutation belongs on ``__iadd__`` / ``+=``.
+    """
+    full = _make_full()
+    sparse = _SummaryBaseModel.model_validate({"length": 50, "duration": 30})
+    full_snapshot = full.model_copy(deep=True)
+    sparse_snapshot = sparse.model_copy(deep=True)
+
+    result = full + sparse
+
+    assert result is not full
+    assert result is not sparse
+    assert full.length == full_snapshot.length
+    assert full.duration == full_snapshot.duration
+    assert sparse.length == sparse_snapshot.length
+    assert sparse.duration == sparse_snapshot.duration

--- a/tests/unit_tests/test_models/test_trips.py
+++ b/tests/unit_tests/test_models/test_trips.py
@@ -1,0 +1,36 @@
+"""Tests for the trips endpoint models."""
+
+from __future__ import annotations
+
+from pytoyoda.models.endpoints.trips import _SummaryBaseModel
+
+
+def test_summary_base_model_parses_partial_payload() -> None:
+    """Real Toyota /v1/trips responses only contain 4 of the 11 summary fields.
+
+    Regression for pytoyoda/ha_toyota#278: without default=None on every field,
+    ``CustomEndpointBaseModel``'s ``invalid_to_none`` wrapper silently converted
+    the whole summary to None when any required field was missing, masking
+    real API data.
+    """
+    partial = {
+        "length": 237614,
+        "duration": 13702,
+        "averageSpeed": 62.43,
+        "fuelConsumption": 15912.0,
+    }
+
+    summary = _SummaryBaseModel.model_validate(partial)
+
+    assert summary.length == 237614
+    assert summary.duration == 13702
+    assert summary.average_speed == 62.43
+    assert summary.fuel_consumption == 15912.0
+    # Fields absent from the payload must be None, not reject the whole model.
+    assert summary.duration_idle is None
+    assert summary.countries is None
+    assert summary.max_speed is None
+    assert summary.length_overspeed is None
+    assert summary.duration_overspeed is None
+    assert summary.length_highway is None
+    assert summary.duration_highway is None

--- a/tests/unit_tests/test_models/test_trips.py
+++ b/tests/unit_tests/test_models/test_trips.py
@@ -34,3 +34,62 @@ def test_summary_base_model_parses_partial_payload() -> None:
     assert summary.duration_overspeed is None
     assert summary.length_highway is None
     assert summary.duration_highway is None
+
+
+def _make_full() -> _SummaryBaseModel:
+    return _SummaryBaseModel.model_validate(
+        {
+            "length": 100,
+            "duration": 60,
+            "averageSpeed": 50.0,
+            "fuelConsumption": 10.0,
+        }
+    )
+
+
+def test_summary_base_model_add_handles_none_fields_on_other() -> None:
+    """``self.length += other.length`` used to crash when other.length was None.
+
+    ``__add__`` mutates ``self`` in place; verify numeric fields missing on
+    ``other`` leave ``self`` unchanged rather than raising TypeError.
+    """
+    full = _make_full()
+    sparse = _SummaryBaseModel.model_validate({"length": 50})
+
+    result = full + sparse
+    assert result.length == 150
+    assert result.duration == 60  # sparse had no duration -> full's value kept
+    assert result.fuel_consumption == 10.0
+    assert result.average_speed == 50.0
+
+
+def test_summary_base_model_add_handles_none_fields_on_self() -> None:
+    """Same crash but from ``self`` side: None += 50 previously raised too."""
+    sparse = _SummaryBaseModel.model_validate({"length": 50})
+    full = _make_full()
+
+    result = sparse + full
+    # length: 50 + 100 = 150, others seed from full since self side was None.
+    assert result.length == 150
+    assert result.duration == 60
+    assert result.average_speed == 50.0
+    assert result.fuel_consumption == 10.0
+
+
+def test_summary_base_model_add_handles_both_none() -> None:
+    """Both sides missing a field -> result stays None, no crash."""
+    a = _SummaryBaseModel.model_validate({"length": 10})
+    b = _SummaryBaseModel.model_validate({"length": 20})
+
+    result = a + b
+    assert result.length == 30
+    assert result.duration is None
+    assert result.average_speed is None
+    assert result.fuel_consumption is None
+    assert result.countries is None
+
+
+def test_summary_base_model_add_noop_when_other_is_none() -> None:
+    """Adding None returns self unchanged (predates this fix, kept as a guard)."""
+    summary = _SummaryBaseModel.model_validate({"length": 42})
+    assert (summary + None).length == 42


### PR DESCRIPTION
## Summary

`_SummaryBaseModel` declared 11 fields with only one default (`fuelConsumption`). The Toyota `/v1/trips` endpoint currently returns only 4 of them at the histogram summary level: `length`, `duration`, `averageSpeed`, `fuelConsumption`. `CustomEndpointBaseModel`'s `invalid_to_none` wrapper then silently converted every partially-populated summary to `None`, masking real API data and eventually crashing the downstream aggregators with `TypeError` or `AttributeError`.

Verified against a live account by dumping the raw `/v1/trips` JSON: histogram summaries contain only the 4 fields above, while the model rejects the payload because the other 7 are missing. This is the failure mode reported in pytoyoda/ha_toyota#278.

## Changes

Two logical commits:

1. **`fix: give every _SummaryBaseModel field a None default`** (root cause). Adds `default=None` to every numeric and list field. Pydantic can now parse partial payloads instead of failing validation and falling through to `invalid_to_none`.

2. **`fix: harden weekly/yearly/daily/monthly summary aggregation against None`** (defensive follow-up, covers the case where Toyota really does omit a field on a given day):
   - `_SummaryBaseModel.__add__` uses `add_with_none` for every numeric field (matching the existing `fuel_consumption` path) and guards `countries.extend`, `max`, and the average calculation against `None`.
   - `_generate_weekly_summaries` and `_generate_yearly_summaries` no longer emit `Summary(None, ...)` objects when every histogram or month in a period has `summary=None`; they skip the period. The downstream `Summary.distance` computed field accesses `self._summary.length` on `None` and raises `AttributeError` on sensor read otherwise.
   - `_generate_daily_summaries` and `_generate_monthly_summaries` filter `None`-summary entries out of the output list.

## Tests

Adds `tests/unit_tests/test_models/test_trips.py`:
- Parsing regression for the current 4-field API payload.
- `__add__` with missing fields on either operand and on both.
- Existing `other is None` no-op path as a guard.

`poetry run pytest` is green (114 passed, up from 109). `poetry run pre-commit run --all-files` is clean.

## Verification on a live account

Installed this branch in a Home Assistant container against an account stuck on the `TypeError` since the API started returning partial payloads. After the fix, `sensor.rav4_current_day_statistics` and peers populate with real kilometre values (for example `268.3 km` for the current week, `4769.1 km` for the current year). Midnight local transition also behaves correctly: the day sensor goes to `unknown` before the first trip of the new day, which matches historical upstream behaviour for the "no data yet" state.

## Out of scope

`_SummaryBaseModel.__add__` computes `average_speed = (self.average_speed + other.average_speed) / 2.0`. That is not a true running average; the last operand gets weighted equally with the whole accumulator. Pre-existing, unrelated to the crash, left untouched to keep this PR focused.

Addresses pytoyoda/ha_toyota#278.
