### PR TITLE
Fix TypeError: unsupported operand type(s) for +=: 'NoneType' and 'NoneType' in vehicle.py

### DIFF
--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -776,11 +776,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
 
             for histogram in week_histograms[1:]:
                 add_with_none(build_hdc, histogram.hdc)
-                if histogram.summary is not None:
-                    if build_summary is not None:
-                        build_summary += histogram.summary
-                    else:
-                        build_summary = histogram.summary
+                add_with_none(build_summary, histogram.summary)
 
             end_date = Arrow(
                 week_histograms[-1].year,
@@ -844,11 +840,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             ):
                 summary_month = date(day=1, month=month.month, year=month.year)
                 add_with_none(build_hdc, month.hdc)
-                if month.summary is not None:
-                    if build_summary is not None:
-                        build_summary += month.summary
-                    else:
-                        build_summary = month.summary
+                add_with_none(build_summary, month.summary)
 
                 if next_month is None or next_month.year != month.year:
                     end_date = min(

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -776,7 +776,11 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
 
             for histogram in week_histograms[1:]:
                 add_with_none(build_hdc, histogram.hdc)
-                build_summary += histogram.summary
+                if histogram.summary is not None:
+                    if build_summary is not None:
+                        build_summary += histogram.summary
+                    else:
+                        build_summary = histogram.summary
 
             end_date = Arrow(
                 week_histograms[-1].year,
@@ -840,7 +844,11 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             ):
                 summary_month = date(day=1, month=month.month, year=month.year)
                 add_with_none(build_hdc, month.hdc)
-                build_summary += month.summary
+                if month.summary is not None:
+                    if build_summary is not None:
+                        build_summary += month.summary
+                    else:
+                        build_summary = month.summary
 
                 if next_month is None or next_month.year != month.year:
                     end_date = min(


### PR DESCRIPTION
This PR fixes a TypeError that occurs when the Toyota API returns incomplete data or a 429 error, causing histogram.summary or month.summary to be None.

When this happens, the integration crashes because Python cannot perform an in-place addition (+=) on a NoneType object. I have added safety checks to ensure that the summary is only added if it is not null.

Fixes #279