### PR TITLE
feat(api): add Vehicle.get_recent_trips() for external batch fetching

### DIFF
--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -706,6 +706,56 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         ret = next(iter(resp.payload.trips), None)
         return None if ret is None else Trip(ret, self._metric)
 
+    async def get_recent_trips(
+        self,
+        limit: int = 5,
+        with_route: bool = False,  # noqa: FBT001, FBT002
+        from_date: date | None = None,
+        to_date: date | None = None,
+        offset: int = 0,
+    ) -> list[Trip]:
+        """Fetch a single page of trips, most-recent-first (one HTTP call).
+
+        Args:
+            limit: Page size, 1..50.
+            with_route: Include per-trip route coordinates (larger payload).
+            from_date: Lower bound, inclusive. Defaults to today minus 90 days.
+            to_date: Upper bound, inclusive. Defaults to today.
+            offset: 0-based offset into the most-recent-first result set.
+
+        Returns:
+            List of Trip models, empty if no trips match.
+
+        Raises:
+            ValueError: ``limit`` outside 1..50, or ``offset`` negative.
+
+        """
+        if not 1 <= limit <= 50:  # noqa: PLR2004
+            msg = f"limit must be between 1 and 50, got {limit}"
+            raise ValueError(msg)
+        if offset < 0:
+            msg = f"offset must be >= 0, got {offset}"
+            raise ValueError(msg)
+        if from_date is None:
+            from_date = date.today() - timedelta(days=90)  # noqa: DTZ011
+        if to_date is None:
+            to_date = date.today()  # noqa: DTZ011
+
+        resp = await self._api.get_trips(
+            self.vin,
+            from_date,
+            to_date,
+            summary=False,
+            limit=limit,
+            offset=offset,
+            route=with_route,
+        )
+
+        if resp.payload is None or not resp.payload.trips:
+            return []
+
+        return [Trip(t, self._metric) for t in resp.payload.trips]
+
     async def refresh_climate_status(self) -> StatusModel:
         """Force update of climate status.
 

--- a/tests/unit_tests/test_models/test_vehicle_get_recent_trips.py
+++ b/tests/unit_tests/test_models/test_vehicle_get_recent_trips.py
@@ -1,0 +1,204 @@
+"""Tests for Vehicle.get_recent_trips."""
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pytoyoda.models.endpoints.trips import _TripModel
+from pytoyoda.models.trips import Trip
+from pytoyoda.models.vehicle import Vehicle
+
+
+def _make_trip_dict(trip_id: str = "abc-123") -> dict:
+    """Minimum-viable _TripModel-shaped dict for round-tripping through Trip()."""
+    return {
+        "id": trip_id,
+        "category": 0,
+        "summary": {
+            "startTs": "2026-04-26T07:06:45Z",
+            "endTs": "2026-04-26T07:15:54Z",
+            "startLat": 47.1652,
+            "startLon": 20.2178,
+            "endLat": 47.1927,
+            "endLon": 20.1938,
+            "length": 4943,
+            "duration": 549,
+        },
+        "scores": None,
+        "behaviours": None,
+        "hdc": None,
+        "route": None,
+    }
+
+
+def _make_vehicle_with_mock_api(trips_payload_factory) -> Vehicle:
+    """Build a Vehicle with a stub Api.get_trips that returns the payload built
+    by trips_payload_factory(call_args). The factory receives the same kwargs
+    that get_trips() was called with, so each test can assert on them."""
+    captured: dict = {}
+
+    async def fake_get_trips(vin, from_date, to_date, **kwargs):
+        captured.update(
+            vin=vin, from_date=from_date, to_date=to_date, **kwargs
+        )
+        payload = trips_payload_factory(captured)
+        return SimpleNamespace(payload=payload)
+
+    api = MagicMock()
+    api.get_trips = AsyncMock(side_effect=fake_get_trips)
+
+    vehicle_info = SimpleNamespace(
+        vin="VIN1234567890",
+        nickname="RAV4",
+    )
+    # Vehicle.__init__ does some work that depends on having both api and
+    # vehicle_info present. We bypass via __new__ to avoid the
+    # CustomAPIBaseModel pydantic init machinery; the methods we test only
+    # need _api, _vehicle_info, _metric set.
+    v = Vehicle.__new__(Vehicle)
+    v._api = api
+    v._vehicle_info = vehicle_info
+    v._metric = True
+    v._endpoint_data = {}
+    # expose for tests that want to assert on call args
+    v._fake_captured = captured  # type: ignore[attr-defined]
+    return v
+
+
+def _payload_with_trips(trip_count: int):
+    """Factory: returns N _TripModel-shaped dicts wrapped as a payload."""
+    def factory(_call_args):
+        trip_dicts = [
+            _make_trip_dict(trip_id=f"trip-{i}") for i in range(trip_count)
+        ]
+        # _TripModel construction via pydantic; shape matches the API response.
+        trips = [_TripModel(**d) for d in trip_dicts]
+        return SimpleNamespace(trips=trips)
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_returns_list_of_trips():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(3))
+    result = await v.get_recent_trips(limit=3)
+    assert len(result) == 3
+    assert all(isinstance(t, Trip) for t in result)
+
+
+@pytest.mark.asyncio
+async def test_passes_limit_and_route_through():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(5))
+    await v.get_recent_trips(limit=5, with_route=True)
+    captured = v._fake_captured  # type: ignore[attr-defined]
+    assert captured["limit"] == 5
+    assert captured["route"] is True
+    assert captured["summary"] is False
+    assert captured["offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_default_dates_are_today_minus_90_to_today():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(1))
+    await v.get_recent_trips()
+    captured = v._fake_captured  # type: ignore[attr-defined]
+    today = date.today()
+    assert captured["to_date"] == today
+    assert captured["from_date"] == today - timedelta(days=90)
+
+
+@pytest.mark.asyncio
+async def test_explicit_dates_override_defaults():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(1))
+    fd, td = date(2026, 4, 1), date(2026, 4, 15)
+    await v.get_recent_trips(from_date=fd, to_date=td)
+    captured = v._fake_captured  # type: ignore[attr-defined]
+    assert captured["from_date"] == fd
+    assert captured["to_date"] == td
+
+
+@pytest.mark.asyncio
+async def test_empty_payload_returns_empty_list():
+    async def fake_get_trips(*_a, **_kw):
+        return SimpleNamespace(payload=None)
+
+    api = MagicMock()
+    api.get_trips = AsyncMock(side_effect=fake_get_trips)
+
+    v = Vehicle.__new__(Vehicle)
+    v._api = api
+    v._vehicle_info = SimpleNamespace(vin="VINX", nickname="X")
+    v._metric = True
+    v._endpoint_data = {}
+
+    result = await v.get_recent_trips()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_payload_with_none_trips_returns_empty_list():
+    """Toyota has been observed returning payloads where trips is None
+    (separate from payload itself being None). Defensive check ensures
+    we don't crash trying to iterate None."""
+    async def fake_get_trips(*_a, **_kw):
+        return SimpleNamespace(payload=SimpleNamespace(trips=None))
+
+    api = MagicMock()
+    api.get_trips = AsyncMock(side_effect=fake_get_trips)
+
+    v = Vehicle.__new__(Vehicle)
+    v._api = api
+    v._vehicle_info = SimpleNamespace(vin="VINX", nickname="X")
+    v._metric = True
+    v._endpoint_data = {}
+
+    result = await v.get_recent_trips()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_zero_trips_returns_empty_list():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(0))
+    result = await v.get_recent_trips(limit=5)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_limit_below_one_raises():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(1))
+    with pytest.raises(ValueError, match="limit must be between 1 and 50"):
+        await v.get_recent_trips(limit=0)
+
+
+@pytest.mark.asyncio
+async def test_limit_above_fifty_raises():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(1))
+    with pytest.raises(ValueError, match="limit must be between 1 and 50"):
+        await v.get_recent_trips(limit=51)
+
+
+@pytest.mark.asyncio
+async def test_with_route_false_by_default():
+    v = _make_vehicle_with_mock_api(_payload_with_trips(2))
+    await v.get_recent_trips(limit=2)
+    captured = v._fake_captured  # type: ignore[attr-defined]
+    assert captured["route"] is False
+
+
+@pytest.mark.asyncio
+async def test_offset_passes_through_to_api():
+    """Non-zero offset reaches Api.get_trips for paginated fetches."""
+    v = _make_vehicle_with_mock_api(_payload_with_trips(3))
+    await v.get_recent_trips(limit=3, offset=10)
+    captured = v._fake_captured  # type: ignore[attr-defined]
+    assert captured["offset"] == 10
+    assert captured["limit"] == 3
+
+
+@pytest.mark.asyncio
+async def test_offset_negative_raises():
+    """Negative offset is rejected before any API call."""
+    v = _make_vehicle_with_mock_api(_payload_with_trips(1))
+    with pytest.raises(ValueError, match="offset must be >= 0"):
+        await v.get_recent_trips(limit=5, offset=-1)


### PR DESCRIPTION
## Summary

Adds a public `Vehicle.get_recent_trips(limit, with_route, from_date, to_date, offset)`
method: a single-HTTP-call paginated fetch of trips with optional route
waypoints. Single page per call, caller-bounded by `limit` and `offset`.

Independent of the cycle's pre-configured `trip_history` endpoint, which
stays at `limit=1, route=False` for backward compatibility (existing
aggregate sensors and the `last_trip` / `trip_history` properties keep
working unchanged).

## Why

External callers that want a per-trip viewer with route waypoints need a
public method that doesn't change the cycle's network behaviour. Today the
options are:

- Reach into `vehicle._api.get_trips(...)` (private, brittle)
- Modify the cycle's endpoint definition (changes network behaviour for
  every consumer, even those who don't need the bigger payload)

Neither is great. This PR adds the third option: a public method that
mirrors `get_last_trip`'s style and exposes the gateway's full
single-page contract - `limit` (1..50, Toyota's documented maximum),
`offset` (0-based, for paginated access), `with_route` (opt-in route
waypoints), plus optional `from_date` / `to_date` overrides.

`get_recent_trips` is intentionally distinct from the existing
`Vehicle.get_trips(from, to, full_route)` which eagerly walks
`next_offset` until the gateway runs out (1..N HTTP calls, returns every
trip in the date range). The new method is a single-page fetch
(exactly 1 HTTP call). Both have a place; this one is for "give me one
page" and supports the official Android app's `androidx.paging`
infinite-scroll pattern (`limit=20, offset=20*page_index`) as well as
trip-by-trip walks (`limit=1, offset=N`).

Concrete first consumer is an upcoming ha_toyota recent-trips sensor (a
rolling cache of the last N trips populated on stop events) but the
method is deliberately generic: any integration building per-trip
detail or paginated history views can use it.

## What's in this PR

- New `Vehicle.get_recent_trips` method (49 LOC, single-page semantics).
  Returns `list[Trip]`, consistent with `get_last_trip`'s return shape.
- 12 unit tests covering: list-return type, param pass-through (limit,
  route, offset, summary=False), default dates (today minus 90 days),
  explicit date override, empty payload returns `[]`, payload with
  `trips=None` returns `[]` (defensive), zero trips returns `[]`,
  `limit < 1` raises ValueError, `limit > 50` raises ValueError,
  default `with_route=False`, `offset` pass-through, negative `offset`
  raises ValueError.

## Test plan

- [x] `poetry run pytest` green (126 unit tests passed, 12 new)
- [x] `poetry run pre-commit run --all-files` clean
- [x] `Trip` wrapper consistency: each result wraps the underlying
  `_TripModel` exactly as `get_last_trip` does (verified via the tests'
  `isinstance(t, Trip)` assertions).
- [x] Verified live on a hybrid RAV4 (EU region): the new method returns
  trips with full route waypoint data (`lat`, `lon`, `overspeed`,
  `highway`, `mode`, `isEv`) populated when `with_route=True`.

## Linked issues

- [#244](https://github.com/pytoyoda/pytoyoda/issues/244) - context for
  the per-trip detail use case (route surfacing via dashboard cards).
  The `summary=false&route=true` shape this PR uses returns route data
  on the accounts I've tested.

No behavioural change to existing call sites.

