### PR TITLE
feat(vehicle): per-endpoint optional flag in update() for resilient cycles

### DIFF
--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -242,9 +242,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                 )
             )
         self._endpoint_collect = [
-            (endpoint.name, endpoint.function, endpoint.optional)
-            for endpoint in self._api_endpoints
-            if endpoint.capable
+            endpoint for endpoint in self._api_endpoints if endpoint.capable
         ]
         # Failures on optional endpoints from the most recent update().
         self._endpoint_errors: dict[str, Exception] = {}
@@ -290,21 +288,24 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
         skip_set = set(skip or [])
         only_set = set(only) if only is not None else None
         self._endpoint_errors = {}
-        for name, function, optional in self._endpoint_collect:
-            if only_set is not None and name not in only_set:
+        for endpoint in self._endpoint_collect:
+            if only_set is not None and endpoint.name not in only_set:
                 continue
-            if name in skip_set:
+            if endpoint.name in skip_set:
                 continue
             try:
-                self._endpoint_data[name] = await function()
+                self._endpoint_data[endpoint.name] = await endpoint.function()
             except Exception as ex:
-                if not optional:
+                if not endpoint.optional:
                     raise
-                self._endpoint_errors[name] = ex
+                self._endpoint_errors[endpoint.name] = ex
+                # Clear any stale payload from a previous successful cycle so
+                # downstream getters return None instead of outdated data.
+                self._endpoint_data.pop(endpoint.name, None)
                 logger.warning(
-                    "Optional endpoint '{}' failed and will be skipped this "
+                    "Optional endpoint '{}' failed and will be cleared this "
                     "cycle: {}: {}",
-                    name,
+                    endpoint.name,
                     type(ex).__name__,
                     ex,
                 )

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -86,6 +86,9 @@ class EndpointDefinition:
     name: str
     capable: bool
     function: Callable
+    # If True, failures here are caught + recorded in
+    # Vehicle._endpoint_errors instead of aborting update().
+    optional: bool = False
 
 
 class Vehicle(CustomAPIBaseModel[type[T]]):
@@ -200,6 +203,9 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                     function=partial(
                         self._api.get_climate_settings, vin=self._vehicle_info.vin
                     ),
+                    # Toyota selectively 500s on this endpoint for some
+                    # accounts. See ha_toyota#291.
+                    optional=True,
                 ),
                 EndpointDefinition(
                     name="climate_status",
@@ -211,6 +217,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                     function=partial(
                         self._api.get_climate_status, vin=self._vehicle_info.vin
                     ),
+                    optional=True,
                 ),
                 EndpointDefinition(
                     name="trip_history",
@@ -235,10 +242,12 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                 )
             )
         self._endpoint_collect = [
-            (endpoint.name, endpoint.function)
+            (endpoint.name, endpoint.function, endpoint.optional)
             for endpoint in self._api_endpoints
             if endpoint.capable
         ]
+        # Failures on optional endpoints from the most recent update().
+        self._endpoint_errors: dict[str, Exception] = {}
 
     async def update(
         self,
@@ -280,12 +289,25 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             raise ValueError(msg)
         skip_set = set(skip or [])
         only_set = set(only) if only is not None else None
-        for name, function in self._endpoint_collect:
+        self._endpoint_errors = {}
+        for name, function, optional in self._endpoint_collect:
             if only_set is not None and name not in only_set:
                 continue
             if name in skip_set:
                 continue
-            self._endpoint_data[name] = await function()
+            try:
+                self._endpoint_data[name] = await function()
+            except Exception as ex:
+                if not optional:
+                    raise
+                self._endpoint_errors[name] = ex
+                logger.warning(
+                    "Optional endpoint '{}' failed and will be skipped this "
+                    "cycle: {}: {}",
+                    name,
+                    type(ex).__name__,
+                    ex,
+                )
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -275,6 +275,14 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
                 /v1/global/remote/status after a wake POST without
                 re-hitting the other endpoints that are already fresh.
 
+        Endpoints registered with ``optional=True`` do not raise on failure:
+        the exception is recorded in ``_endpoint_errors[name]`` and the
+        endpoint's ``_endpoint_data`` entry is cleared, so downstream getters
+        return None for that cycle instead of stale data (note the asymmetry
+        with ``skip``, which retains the previous data). Error records are
+        kept until the endpoint is attempted again, so partial updates via
+        ``skip``/``only`` leave other endpoints' diagnostics intact.
+
         Returns:
             None
 
@@ -287,12 +295,15 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
             raise ValueError(msg)
         skip_set = set(skip or [])
         only_set = set(only) if only is not None else None
-        self._endpoint_errors = {}
         for endpoint in self._endpoint_collect:
             if only_set is not None and endpoint.name not in only_set:
                 continue
             if endpoint.name in skip_set:
                 continue
+            # Clear only the record of endpoints attempted this cycle, so a
+            # partial update (skip/only) does not erase the diagnostics of
+            # endpoints it never retried.
+            self._endpoint_errors.pop(endpoint.name, None)
             try:
                 self._endpoint_data[endpoint.name] = await endpoint.function()
             except Exception as ex:

--- a/tests/unit_tests/test_models/test_vehicle_update.py
+++ b/tests/unit_tests/test_models/test_vehicle_update.py
@@ -1,0 +1,179 @@
+"""Tests for Vehicle.update() - per-endpoint optional flag handling.
+
+Covers the contract introduced for ha_toyota#291: an endpoint marked
+`optional=True` whose call raises is caught, recorded in
+Vehicle._endpoint_errors, and does NOT abort the rest of the cycle.
+Required endpoints (default) still propagate as before.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pytoyoda.models.vehicle import EndpointDefinition, Vehicle
+
+
+class _FakeApi:
+    """Stub Api object that satisfies Vehicle's constructor."""
+
+    pass
+
+
+class _FakeVehicleInfo:
+    """Minimal vehicle info shape: a vin and feature/capability stubs."""
+
+    class _Features:
+        pass
+
+    class _ExtCaps:
+        pass
+
+    def __init__(self, vin: str = "TESTVIN0000000001") -> None:
+        self.vin = vin
+        self.features = self._Features()
+        self.extended_capabilities = self._ExtCaps()
+
+
+def _build_vehicle_with_endpoints(endpoints: list[EndpointDefinition]) -> Vehicle:
+    """Build a Vehicle and override _api_endpoints / _endpoint_collect.
+
+    Bypasses Vehicle.__init__'s endpoint construction so tests can inject
+    arbitrary EndpointDefinition lists with controlled call behaviour.
+    """
+    v = Vehicle.__new__(Vehicle)
+    v._api = _FakeApi()
+    v._vehicle_info = _FakeVehicleInfo()
+    v._metric = True
+    v._endpoint_data = {}
+    v._endpoint_errors = {}
+    v._api_endpoints = endpoints
+    v._endpoint_collect = [
+        (e.name, e.function, e.optional) for e in endpoints if e.capable
+    ]
+    return v
+
+
+@pytest.mark.asyncio
+async def test_required_endpoint_failure_propagates() -> None:
+    """A required endpoint that raises causes update() to raise."""
+    boom = RuntimeError("required endpoint exploded")
+
+    async def good() -> str:
+        return "fresh"
+
+    async def bad() -> Any:
+        raise boom
+
+    v = _build_vehicle_with_endpoints(
+        [
+            EndpointDefinition("a", capable=True, function=good),
+            EndpointDefinition("b", capable=True, function=bad),  # required (default)
+            EndpointDefinition("c", capable=True, function=good),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="required endpoint exploded"):
+        await v.update()
+    # 'a' fetched before the failure should be in data; 'c' never ran.
+    assert v._endpoint_data.get("a") == "fresh"
+    assert "c" not in v._endpoint_data
+    assert v._endpoint_errors == {}
+
+
+@pytest.mark.asyncio
+async def test_optional_endpoint_failure_swallowed_and_recorded() -> None:
+    """An optional endpoint that raises is caught + recorded; loop continues."""
+    boom = RuntimeError("climate 500")
+
+    async def good_a() -> str:
+        return "a-value"
+
+    async def bad() -> Any:
+        raise boom
+
+    async def good_c() -> str:
+        return "c-value"
+
+    v = _build_vehicle_with_endpoints(
+        [
+            EndpointDefinition("a", capable=True, function=good_a),
+            EndpointDefinition("b", capable=True, function=bad, optional=True),
+            EndpointDefinition("c", capable=True, function=good_c),
+        ]
+    )
+
+    # Should not raise.
+    await v.update()
+    assert v._endpoint_data["a"] == "a-value"
+    assert "b" not in v._endpoint_data
+    assert v._endpoint_data["c"] == "c-value"
+    assert "b" in v._endpoint_errors
+    assert v._endpoint_errors["b"] is boom
+
+
+@pytest.mark.asyncio
+async def test_endpoint_errors_resets_each_update() -> None:
+    """A successful re-run clears stale entries from _endpoint_errors."""
+    state = {"raise": True}
+
+    async def maybe_bad() -> str:
+        if state["raise"]:
+            raise RuntimeError("transient")
+        return "now-fine"
+
+    v = _build_vehicle_with_endpoints(
+        [EndpointDefinition("x", capable=True, function=maybe_bad, optional=True)]
+    )
+
+    await v.update()
+    assert "x" in v._endpoint_errors
+
+    state["raise"] = False
+    await v.update()
+    assert v._endpoint_data["x"] == "now-fine"
+    assert "x" not in v._endpoint_errors  # cleared on the new cycle
+
+
+@pytest.mark.asyncio
+async def test_skip_does_not_record_as_error() -> None:
+    """Endpoints filtered via skip= are not called; not in errors."""
+    async def good() -> str:
+        return "ok"
+
+    async def boom() -> Any:
+        raise RuntimeError("would have failed")
+
+    v = _build_vehicle_with_endpoints(
+        [
+            EndpointDefinition("a", capable=True, function=good),
+            EndpointDefinition("b", capable=True, function=boom, optional=True),
+        ]
+    )
+
+    await v.update(skip=["b"])
+    assert v._endpoint_data == {"a": "ok"}
+    assert v._endpoint_errors == {}
+
+
+@pytest.mark.asyncio
+async def test_only_filter_works_with_optional_flag() -> None:
+    """only= filters endpoints; optional flag still applies for those that run."""
+    async def good() -> str:
+        return "ok"
+
+    async def boom() -> Any:
+        raise RuntimeError("optional boom")
+
+    v = _build_vehicle_with_endpoints(
+        [
+            EndpointDefinition("a", capable=True, function=good),
+            EndpointDefinition("b", capable=True, function=boom, optional=True),
+            EndpointDefinition("c", capable=True, function=good),
+        ]
+    )
+
+    await v.update(only=["b"])
+    assert v._endpoint_data == {}  # b raised, a/c filtered out
+    assert "b" in v._endpoint_errors

--- a/tests/unit_tests/test_models/test_vehicle_update.py
+++ b/tests/unit_tests/test_models/test_vehicle_update.py
@@ -18,8 +18,6 @@ from pytoyoda.models.vehicle import EndpointDefinition, Vehicle
 class _FakeApi:
     """Stub Api object that satisfies Vehicle's constructor."""
 
-    pass
-
 
 class _FakeVehicleInfo:
     """Minimal vehicle info shape: a vin and feature/capability stubs."""
@@ -49,9 +47,7 @@ def _build_vehicle_with_endpoints(endpoints: list[EndpointDefinition]) -> Vehicl
     v._endpoint_data = {}
     v._endpoint_errors = {}
     v._api_endpoints = endpoints
-    v._endpoint_collect = [
-        (e.name, e.function, e.optional) for e in endpoints if e.capable
-    ]
+    v._endpoint_collect = [e for e in endpoints if e.capable]
     return v
 
 
@@ -137,8 +133,38 @@ async def test_endpoint_errors_resets_each_update() -> None:
 
 
 @pytest.mark.asyncio
+async def test_optional_failure_clears_stale_data() -> None:
+    """A failure on an optional endpoint must clear last cycle's payload.
+
+    Otherwise downstream getters keep returning stale data instead of None,
+    which would silently mask the failure to the user.
+    """
+    state = {"raise": False}
+
+    async def sometimes_bad() -> str:
+        if state["raise"]:
+            raise RuntimeError("now broken")
+        return "fresh"
+
+    v = _build_vehicle_with_endpoints(
+        [EndpointDefinition("x", capable=True, function=sometimes_bad, optional=True)]
+    )
+
+    # Cycle 1: success populates _endpoint_data["x"].
+    await v.update()
+    assert v._endpoint_data["x"] == "fresh"
+
+    # Cycle 2: failure must remove the stale entry.
+    state["raise"] = True
+    await v.update()
+    assert "x" not in v._endpoint_data
+    assert "x" in v._endpoint_errors
+
+
+@pytest.mark.asyncio
 async def test_skip_does_not_record_as_error() -> None:
     """Endpoints filtered via skip= are not called; not in errors."""
+
     async def good() -> str:
         return "ok"
 
@@ -160,6 +186,7 @@ async def test_skip_does_not_record_as_error() -> None:
 @pytest.mark.asyncio
 async def test_only_filter_works_with_optional_flag() -> None:
     """only= filters endpoints; optional flag still applies for those that run."""
+
     async def good() -> str:
         return "ok"
 

--- a/tests/unit_tests/test_models/test_vehicle_update.py
+++ b/tests/unit_tests/test_models/test_vehicle_update.py
@@ -110,8 +110,13 @@ async def test_optional_endpoint_failure_swallowed_and_recorded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_endpoint_errors_resets_each_update() -> None:
-    """A successful re-run clears stale entries from _endpoint_errors."""
+async def test_endpoint_errors_cleared_per_attempted_endpoint() -> None:
+    """Error records clear on re-attempt, but survive partial updates.
+
+    A partial update via only=/skip= must not erase the diagnostics of
+    endpoints it never retried (ha_toyota's smart-refresh strategy issues
+    exactly such partial updates every cycle).
+    """
     state = {"raise": True}
 
     async def maybe_bad() -> str:
@@ -119,17 +124,27 @@ async def test_endpoint_errors_resets_each_update() -> None:
             raise RuntimeError("transient")
         return "now-fine"
 
+    async def fine() -> str:
+        return "ok"
+
     v = _build_vehicle_with_endpoints(
-        [EndpointDefinition("x", capable=True, function=maybe_bad, optional=True)]
+        [
+            EndpointDefinition("x", capable=True, function=maybe_bad, optional=True),
+            EndpointDefinition("y", capable=True, function=fine, optional=True),
+        ]
     )
 
     await v.update()
     assert "x" in v._endpoint_errors
 
+    # Partial update that never retries "x": its error record must survive.
+    await v.update(only=["y"])
+    assert "x" in v._endpoint_errors
+
     state["raise"] = False
     await v.update()
     assert v._endpoint_data["x"] == "now-fine"
-    assert "x" not in v._endpoint_errors  # cleared on the new cycle
+    assert "x" not in v._endpoint_errors  # cleared on the re-attempt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Motivation

Some Toyota EU accounts get a persistent HTTP 500 from `GET /v1/global/remote/climate-settings` (response code `ONE-GLOBAL-RS-40000`, "Command execution interrupted"). The failure is server-side, account-specific, deterministic across retries, and cannot be predicted from any client-visible capability flag - a vehicle with `features.climate_start_engine: True` and `extended_capabilities.climate_capable: True` and every other climate flag True can still 500 persistently on this endpoint.

When this happens today, `Vehicle.update()` propagates the exception, which means:

- Initial setup of the integration fails with `ConfigEntryNotReady` and the user has no working integration at all - even though every other endpoint (`climate-status`, `location`, `telemetry`, `notifications`, etc.) returns 200 cleanly.
- The DataUpdateCoordinator marks the entire vehicle as failed on every cycle, all entities go unavailable.

Ha_toyota issue: pytoyoda/ha_toyota#291.

## What this change does

Introduces an `optional: bool = False` field on `EndpointDefinition`. When `optional=True`, exceptions from the endpoint's fetch function are caught inside `Vehicle.update()`, recorded in `Vehicle._endpoint_errors[name]`, and a warning is logged. The rest of the update cycle continues.

Default is `False`, so existing endpoints behave exactly as before - failures still propagate, the integration still gets a clear signal when something genuinely required is broken.

Marks `climate_settings` and `climate_status` as `optional=True`. Both have downstream consumers that already handle missing data via `_endpoint_data.get(name, None)` and `Optional[...]` return types, so a missing payload does not cascade into other failures.

## Why this approach (vs alternatives considered)

- **Per-endpoint optional flag (this PR)**: client-side resilience, single source of truth in pytoyoda, ha_toyota only needs a manifest pin bump. Affects all consumers of pytoyoda equally. Endpoints that should never be silently swallowed (vehicle list, fundamental status) keep `optional=False`.
- **Catch broadly in ha_toyota's coordinator**: would require ha_toyota changes + consumer-by-consumer error handling for missing climate data. Pushes resilience policy out of the library where the endpoint is defined.
- **Pre-flight capability check before fetching climate-settings**: no client-visible flag predicts the 500 (verified across 4 vehicles in #291 and reverse-engineering the official Toyota app's logic - there is no client-side gate before this call). Would not help.

## Tests

Added 6 unit tests in `tests/unit_tests/test_models/test_vehicle_update.py`:

- `test_required_endpoint_failure_propagates` - default `optional=False` still raises.
- `test_optional_endpoint_failure_swallowed_and_recorded` - `optional=True` catches, records in `_endpoint_errors`, continues.
- `test_endpoint_errors_cleared_per_attempted_endpoint` - error records clear when the endpoint is retried, but survive partial updates (`only=`/`skip=`) that never touch the endpoint.
- `test_optional_failure_clears_stale_data` - a failed optional endpoint clears its previous `_endpoint_data` entry so consumers get None instead of stale data (deliberate asymmetry with `skip`, which retains data; both behaviours documented in the `update()` docstring).
- `test_skip_does_not_record_as_error` - endpoints filtered out via `skip` are not treated as errors.
- `test_only_filter_works_with_optional_flag` - when called with `only=[...]`, optional behaviour still applies inside the filtered set.

All 120 unit tests pass (114 existing + 6 new). `ruff` clean (the single pre-existing `TC003` on main's `controller.py` is unrelated).

## Validation

Tested end-to-end against:

1. **A real failing account** (ha_toyota#291): pip-installed this branch, restarted HA. Integration set up successfully, all non-climate entities populated, `Optional endpoint 'climate_settings' failed: ...` warning fired as expected. Confirmed by user.
2. **A healthy account** (regression): same install procedure on an account where climate-settings returns either `200 OK` or `200 empty`. Integration set up cleanly, all entities populated, no errors, no behavioural change for the success path.
3. **Test gist** for reproducibility: https://gist.github.com/nledenyi/260a93164a60defaa318f12d2cde9341

## Backward compatibility

- New `optional` field defaults to `False`, so every existing `EndpointDefinition` instance keeps its current behaviour.
- `Vehicle._endpoint_errors` is a new attribute on the instance, not a public API change. External callers can inspect it if they want to surface "endpoint X failed in the last cycle" diagnostics.
- No changes to public method signatures.

Diff: `pytoyoda/models/vehicle.py` +41/-7 (net), `tests/unit_tests/test_models/test_vehicle_update.py` +221.

