### PR TITLE
fix(status): read vehicle status from /v1/vehicle/status (part of #267)

### DIFF
--- a/pytoyoda/const.py
+++ b/pytoyoda/const.py
@@ -17,7 +17,10 @@ VEHICLE_ASSOCIATION_ENDPOINT = "/v1/vehicle-association/vehicle"
 VEHICLE_GUID_ENDPOINT = "/v2/vehicle/guid"
 VEHICLE_LOCATION_ENDPOINT = "/v1/location"
 VEHICLE_HEALTH_STATUS_ENDPOINT = "/v1/vehiclehealth/status"
-VEHICLE_GLOBAL_REMOTE_STATUS_ENDPOINT = "/v1/global/remote/status"
+# Migrated 2026-07: Toyota retired /v1/global/remote/status (now fenced behind
+# AWS SigV4 -> returns APIGW-403). The live app reads status from /v1/vehicle/status
+# on the plain-Bearer authorizer. Const name kept to avoid churn in api.py.
+VEHICLE_GLOBAL_REMOTE_STATUS_ENDPOINT = "/v1/vehicle/status"
 VEHICLE_GLOBAL_REMOTE_REFRESH_STATUS_ENDPOINT = "/v1/global/remote/refresh-status"
 VEHICLE_GLOBAL_REMOTE_ELECTRIC_STATUS_ENDPOINT = "/v1/global/remote/electric/status"
 VEHICLE_GLOBAL_REMOTE_ELECTRIC_REALTIME_STATUS_ENDPOINT = (

--- a/pytoyoda/models/endpoints/status.py
+++ b/pytoyoda/models/endpoints/status.py
@@ -55,23 +55,6 @@ class WindowsModel(CustomEndpointBaseModel):
     rear_right: ComponentStateModel | None = Field(alias="rearRight", default=None)
 
 
-class LightsModel(CustomEndpointBaseModel):
-    """Exterior light states (new in the v1/vehicle/status payload)."""
-
-    hazard: ComponentStateModel | None = None
-    head: ComponentStateModel | None = None
-    tail: ComponentStateModel | None = None
-
-
-class RearSeatReminderModel(CustomEndpointBaseModel):
-    """Rear-seat occupant reminder state (new in the v1/vehicle/status payload)."""
-
-    reason: str | None = None
-    last_update_timestamp: datetime | None = Field(
-        alias="lastUpdateTimestamp", default=None
-    )
-
-
 class RemoteStatusModel(CustomEndpointBaseModel):
     """Model representing the vehicle status payload (``/v1/vehicle/status``).
 
@@ -84,8 +67,6 @@ class RemoteStatusModel(CustomEndpointBaseModel):
             map physical rear-left/rear-right to driver/passenger rear.
         doors: Per-door lock/open state.
         windows: Per-window open state.
-        lights: Exterior light state.
-        rear_seat_reminder: Rear-seat occupant reminder.
 
     """
 
@@ -100,10 +81,6 @@ class RemoteStatusModel(CustomEndpointBaseModel):
     left_hand_drive: bool | None = Field(alias="leftHandDrive", default=None)
     doors: DoorsModel | None = None
     windows: WindowsModel | None = None
-    lights: LightsModel | None = None
-    rear_seat_reminder: RearSeatReminderModel | None = Field(
-        alias="rearSeatReminder", default=None
-    )
 
     @property
     def occurrence_date(self) -> datetime | None:

--- a/pytoyoda/models/endpoints/status.py
+++ b/pytoyoda/models/endpoints/status.py
@@ -1,86 +1,127 @@
-"""Toyota Connected Services API - Status Models."""
+"""Toyota Connected Services API - Status Models.
+
+Models for the ``/v1/vehicle/status`` endpoint. Toyota retired the previous
+``/v1/global/remote/status`` route in mid-2026 (it now sits behind AWS SigV4 and
+returns ``APIGW-403``); the live app moved to ``/v1/vehicle/status``, whose payload
+is directly typed (per-component lock/open/light state) rather than the old
+category/section/value blob.
+"""
 
 from datetime import datetime
 
 from pydantic import Field
 
-from pytoyoda.models.endpoints.common import StatusModel, UnitValueModel
+from pytoyoda.models.endpoints.common import StatusModel
 from pytoyoda.utils.models import CustomEndpointBaseModel
 
 
-class _ValueStatusModel(CustomEndpointBaseModel):
-    value: str | None
-    status: int | None
+class ComponentStateModel(CustomEndpointBaseModel):
+    """A single component state plus when it was last observed.
 
-
-class SectionModel(CustomEndpointBaseModel):
-    """Model representing the status category of a vehicle.
-
-    Attributes:
-        section (str): The section of a vehicle status category.
-        values (list[_ValueStatusModel]): A list of values corresponding
-            status informations.
-
+    ``status`` carries the backend enum string, e.g. ``"locked"``/``"unlocked"``
+    for locks, ``"open"``/``"close"`` for open state, ``"on"``/``"off"`` for lights.
     """
 
-    section: str | None
-    values: list[_ValueStatusModel] | None
-
-
-class VehicleStatusModel(CustomEndpointBaseModel):
-    """Model representing the status category of a vehicle.
-
-    Attributes:
-        category (str): The status category of the vehicle.
-        display_order (int): The order in which the status category is displayed
-            inside the MyToyota App.
-        sections (list[SectionModel]): The different sections belonging to the category.
-
-    """
-
-    category: str | None
-    display_order: int | None = Field(alias="displayOrder")
-    sections: list[SectionModel] | None
-
-
-class _TelemetryModel(CustomEndpointBaseModel):
-    fugage: UnitValueModel | None = None
-    rage: UnitValueModel | None = None
-    odo: UnitValueModel | None
-
-
-class RemoteStatusModel(CustomEndpointBaseModel):
-    """Model representing the remote status of a vehicle.
-
-    Attributes:
-        vehicle_status (list[_VehicleStatusModel]): The status of the vehicle.
-        telemetry (_TelemetryModel): The telemetry data of the vehicle.
-        occurrence_date (datetime): The date of the occurrence.
-        caution_overall_count (int): The overall count of cautions.
-        latitude (float): The latitude of the vehicle's location.
-        longitude (float): The longitude of the vehicle's location.
-        location_acquisition_datetime (datetime): The datetime of location acquisition.
-
-    """
-
-    vehicle_status: list[VehicleStatusModel] | None = Field(alias="vehicleStatus")
-    telemetry: _TelemetryModel | None
-    occurrence_date: datetime | None = Field(alias="occurrenceDate")
-    caution_overall_count: int | None = Field(alias="cautionOverallCount")
-    latitude: float | None
-    longitude: float | None
-    location_acquisition_datetime: datetime | None = Field(
-        alias="locationAcquisitionDatetime"
+    status: str | None = None
+    last_update_timestamp: datetime | None = Field(
+        alias="lastUpdateTimestamp", default=None
     )
 
 
+class DoorModel(CustomEndpointBaseModel):
+    """A door with lock and/or open sub-state (the hood reports open only)."""
+
+    lock_status: ComponentStateModel | None = Field(alias="lockStatus", default=None)
+    open_status: ComponentStateModel | None = Field(alias="openStatus", default=None)
+
+
+class DoorsModel(CustomEndpointBaseModel):
+    """The set of doors keyed by physical position (+ hood)."""
+
+    driver: DoorModel | None = None
+    passenger: DoorModel | None = None
+    rear_left: DoorModel | None = Field(alias="rearLeft", default=None)
+    rear_right: DoorModel | None = Field(alias="rearRight", default=None)
+    rear_back: DoorModel | None = Field(alias="rearBack", default=None)
+    hood: DoorModel | None = None
+
+
+class WindowsModel(CustomEndpointBaseModel):
+    """The set of windows keyed by physical position."""
+
+    driver: ComponentStateModel | None = None
+    passenger: ComponentStateModel | None = None
+    rear_left: ComponentStateModel | None = Field(alias="rearLeft", default=None)
+    rear_right: ComponentStateModel | None = Field(alias="rearRight", default=None)
+
+
+class LightsModel(CustomEndpointBaseModel):
+    """Exterior light states (new in the v1/vehicle/status payload)."""
+
+    hazard: ComponentStateModel | None = None
+    head: ComponentStateModel | None = None
+    tail: ComponentStateModel | None = None
+
+
+class RearSeatReminderModel(CustomEndpointBaseModel):
+    """Rear-seat occupant reminder state (new in the v1/vehicle/status payload)."""
+
+    reason: str | None = None
+    last_update_timestamp: datetime | None = Field(
+        alias="lastUpdateTimestamp", default=None
+    )
+
+
+class RemoteStatusModel(CustomEndpointBaseModel):
+    """Model representing the vehicle status payload (``/v1/vehicle/status``).
+
+    Attributes:
+        vin: Vehicle Identification Number.
+        last_update_timestamp: When the vehicle last reported this status.
+        overall_status: Aggregate status string (e.g. ``"ok"``).
+        overall_warning_counts: Number of active warnings.
+        left_hand_drive: Whether the vehicle is left-hand drive. Nullable; used to
+            map physical rear-left/rear-right to driver/passenger rear.
+        doors: Per-door lock/open state.
+        windows: Per-window open state.
+        lights: Exterior light state.
+        rear_seat_reminder: Rear-seat occupant reminder.
+
+    """
+
+    vin: str | None = None
+    last_update_timestamp: datetime | None = Field(
+        alias="lastUpdateTimestamp", default=None
+    )
+    overall_status: str | None = Field(alias="overallStatus", default=None)
+    overall_warning_counts: int | None = Field(
+        alias="overallWarningCounts", default=None
+    )
+    left_hand_drive: bool | None = Field(alias="leftHandDrive", default=None)
+    doors: DoorsModel | None = None
+    windows: WindowsModel | None = None
+    lights: LightsModel | None = None
+    rear_seat_reminder: RearSeatReminderModel | None = Field(
+        alias="rearSeatReminder", default=None
+    )
+
+    @property
+    def occurrence_date(self) -> datetime | None:
+        """Back-compat alias for the retired ``/v1/global/remote/status`` field.
+
+        Consumers (``LockStatus.last_updated`` and ha_toyota's refresh strategy)
+        read ``occurrence_date``; the new endpoint calls it ``lastUpdateTimestamp``.
+        """
+        return self.last_update_timestamp
+
+
 class RemoteStatusResponseModel(StatusModel):
-    r"""Model representing a remote status response.
+    r"""Model representing a vehicle status response.
 
     Inherits from StatusModel.
 
     Attributes:
-        payload (Optional[RemoteStatusModel], optional): The remote status payload.
+        payload (Optional[RemoteStatusModel], optional): The status payload.
             Defaults to None.
 
     """

--- a/pytoyoda/models/lock_status.py
+++ b/pytoyoda/models/lock_status.py
@@ -8,67 +8,54 @@ from typing import Optional
 from pydantic import computed_field
 
 from pytoyoda.models.endpoints.status import (
+    ComponentStateModel,
+    DoorModel,
     RemoteStatusModel,
     RemoteStatusResponseModel,
-    SectionModel,
-    VehicleStatusModel,
 )
 from pytoyoda.utils.models import CustomAPIBaseModel
 
+_CLOSED_VALUES = {"close", "closed"}
+_OPEN_VALUES = {"open"}
 
-class StatusHelper:
-    """Helper class for status operations."""
 
-    @staticmethod
-    def get_category(
-        data: RemoteStatusModel | None, category: str
-    ) -> VehicleStatusModel | None:
-        """Search for a category in Vehicle Status."""
-        if data and data.vehicle_status:
-            return next(
-                (item for item in data.vehicle_status if item.category == category),
-                None,
-            )
+def _is_closed(status: str | None) -> bool | None:
+    """Interpret an open-state string: closed=True, open=False, unknown=None."""
+    if status is None:
         return None
+    lowered = status.lower()
+    if lowered in _CLOSED_VALUES:
+        return True
+    if lowered in _OPEN_VALUES:
+        return False
+    return None
 
-    @staticmethod
-    def get_section(
-        data: VehicleStatusModel | None, section: str
-    ) -> SectionModel | None:
-        """Search for a section in the category."""
-        if data and data.sections:
-            return next(
-                (item for item in data.sections if item.section == section),
-                None,
-            )
+
+def _is_locked(status: str | None) -> bool | None:
+    """Interpret a lock-state string: locked=True, unlocked=False, unknown=None."""
+    if status is None:
         return None
-
-    @staticmethod
-    def get_status(data: SectionModel | None, status: str) -> bool | None:
-        """Determine the status of a value in the section."""
-        if data and data.values:
-            item_status = next(
-                (item.status for item in data.values if item.value == status),
-                None,
-            )
-            return item_status if item_status is None else not bool(item_status)
-        return None
-
-    @classmethod
-    def get_component_section(
-        cls, status: RemoteStatusModel | None, category: str, section: str
-    ) -> SectionModel | None:
-        """Retrieve component section from a given category."""
-        category_data = cls.get_category(status, category=category)
-        return cls.get_section(category_data, section=section)
+    lowered = status.lower()
+    if lowered == "locked":
+        return True
+    if lowered == "unlocked":
+        return False
+    return None
 
 
-class Door(CustomAPIBaseModel[Optional[SectionModel]]):
+def _driver_on_left(status: RemoteStatusModel | None) -> bool:
+    """Whether the driver sits on the left (LHD). Defaults to LHD when unknown."""
+    if status is None or status.left_hand_drive is None:
+        return True
+    return status.left_hand_drive
+
+
+class Door(CustomAPIBaseModel[Optional[DoorModel]]):
     """Door/hood data model."""
 
     def __init__(
         self,
-        status: SectionModel | None = None,
+        status: DoorModel | None = None,
         **kwargs: dict,
     ) -> None:
         """Initialise Door Model."""
@@ -81,17 +68,38 @@ class Door(CustomAPIBaseModel[Optional[SectionModel]]):
     @property
     def closed(self) -> bool | None:
         """If the door is closed."""
-        return StatusHelper.get_status(self._data, status="carstatus_closed")
+        if self._data is None or self._data.open_status is None:
+            return None
+        return _is_closed(self._data.open_status.status)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def locked(self) -> bool | None:
         """If the door is locked."""
-        if StatusHelper.get_status(self._data, status="carstatus_locked") is True:
-            return True
-        if StatusHelper.get_status(self._data, status="carstatus_unlocked") is False:
-            return False
-        return None
+        if self._data is None or self._data.lock_status is None:
+            return None
+        return _is_locked(self._data.lock_status.status)
+
+
+class Window(CustomAPIBaseModel[Optional[ComponentStateModel]]):
+    """Window data model."""
+
+    def __init__(
+        self,
+        status: ComponentStateModel | None = None,
+        **kwargs: dict,
+    ) -> None:
+        """Initialise Window Model."""
+        super().__init__(
+            data=status,
+            **kwargs,
+        )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def closed(self) -> bool | None:
+        """Window closed state."""
+        return None if self._data is None else _is_closed(self._data.status)
 
 
 class Doors(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
@@ -108,81 +116,52 @@ class Doors(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
             **kwargs,
         )
 
+    def _rear(self, *, driver_side: bool) -> Door:
+        """Resolve a rear door by driver/passenger side via left_hand_drive.
+
+        The payload keys rear doors physically (rearLeft/rearRight); the driver
+        is on the left in an LHD car.
+        """
+        doors = self._data.doors if self._data else None
+        if doors is None:
+            return Door(None)
+        on_left = _driver_on_left(self._data)
+        if driver_side:
+            return Door(doors.rear_left if on_left else doors.rear_right)
+        return Door(doors.rear_right if on_left else doors.rear_left)
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def driver_seat(self) -> Door | None:
         """Driver seat door."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_driver",
-            section="carstatus_item_driver_door",
-        )
-        return Door(section)
+        doors = self._data.doors if self._data else None
+        return Door(doors.driver if doors else None)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def driver_rear_seat(self) -> Door | None:
-        """Right rearseat door."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_driver",
-            section="carstatus_item_driver_rear_door",
-        )
-        return Door(section)
+        """Driver-side rear door."""
+        return self._rear(driver_side=True)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def passenger_seat(self) -> Door | None:
         """Passenger seat door."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_passenger",
-            section="carstatus_item_passenger_door",
-        )
-        return Door(section)
+        doors = self._data.doors if self._data else None
+        return Door(doors.passenger if doors else None)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def passenger_rear_seat(self) -> Door | None:
-        """Left rearseat door."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_passenger",
-            section="carstatus_item_passenger_rear_door",
-        )
-        return Door(section)
+        """Passenger-side rear door."""
+        return self._rear(driver_side=False)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def trunk(self) -> Door | None:
-        """Trunk."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_other",
-            section="carstatus_item_rear_hatch",
-        )
-        return Door(section)
-
-
-class Window(CustomAPIBaseModel[Optional[SectionModel]]):
-    """Window data model."""
-
-    def __init__(
-        self,
-        status: SectionModel | None = None,
-        **kwargs: dict,
-    ) -> None:
-        """Initialise Window Model."""
-        super().__init__(
-            data=status,
-            **kwargs,
-        )
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def closed(self) -> bool | None:
-        """Window closed state."""
-        return StatusHelper.get_status(self._data, status="carstatus_closed")
+        """Trunk (rear hatch)."""
+        doors = self._data.doors if self._data else None
+        return Door(doors.rear_back if doors else None)
 
 
 class Windows(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
@@ -199,49 +178,40 @@ class Windows(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
             **kwargs,
         )
 
+    def _rear(self, *, driver_side: bool) -> Window:
+        windows = self._data.windows if self._data else None
+        if windows is None:
+            return Window(None)
+        on_left = _driver_on_left(self._data)
+        if driver_side:
+            return Window(windows.rear_left if on_left else windows.rear_right)
+        return Window(windows.rear_right if on_left else windows.rear_left)
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def driver_seat(self) -> Window | None:
         """Driver seat window."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_driver",
-            section="carstatus_item_driver_window",
-        )
-        return Window(section)
+        windows = self._data.windows if self._data else None
+        return Window(windows.driver if windows else None)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def driver_rear_seat(self) -> Window | None:
-        """Right rearseat window."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_driver",
-            section="carstatus_item_driver_rear_window",
-        )
-        return Window(section)
+        """Driver-side rear window."""
+        return self._rear(driver_side=True)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def passenger_seat(self) -> Window | None:
         """Passenger seat window."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_passenger",
-            section="carstatus_item_passenger_window",
-        )
-        return Window(section)
+        windows = self._data.windows if self._data else None
+        return Window(windows.passenger if windows else None)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def passenger_rear_seat(self) -> Window | None:
-        """Left rearseat window."""
-        section = StatusHelper.get_component_section(
-            self._data,
-            category="carstatus_category_passenger",
-            section="carstatus_item_passenger_rear_window",
-        )
-        return Window(section)
+        """Passenger-side rear window."""
+        return self._rear(driver_side=False)
 
 
 class LockStatus(CustomAPIBaseModel[Optional[RemoteStatusResponseModel]]):
@@ -264,20 +234,20 @@ class LockStatus(CustomAPIBaseModel[Optional[RemoteStatusResponseModel]]):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def last_updated(self) -> datetime | None:
-        """Last time data was recieved from the car."""
-        return self._status if self._status is None else self._status.occurrence_date
+        """Last time data was received from the car."""
+        return None if self._status is None else self._status.occurrence_date
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def doors(self) -> Doors | None:
         """Doors."""
-        return self._status if self._status is None else Doors(self._status)
+        return None if self._status is None else Doors(self._status)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def windows(self) -> Windows | None:
         """Windows."""
-        return self._status if self._status is None else Windows(self._status)
+        return None if self._status is None else Windows(self._status)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -285,9 +255,5 @@ class LockStatus(CustomAPIBaseModel[Optional[RemoteStatusResponseModel]]):
         """Hood."""
         if self._status is None:
             return None
-        section = StatusHelper.get_component_section(
-            self._status,
-            category="carstatus_category_other",
-            section="carstatus_item_hood",
-        )
-        return Door(section)
+        doors = self._status.doors
+        return Door(doors.hood if doors else None)

--- a/pytoyoda/models/lock_status.py
+++ b/pytoyoda/models/lock_status.py
@@ -15,30 +15,28 @@ from pytoyoda.models.endpoints.status import (
 )
 from pytoyoda.utils.models import CustomAPIBaseModel
 
-_CLOSED_VALUES = {"close", "closed"}
-_OPEN_VALUES = {"open"}
+_CLOSED_VALUES = frozenset({"close", "closed"})
+_OPEN_VALUES = frozenset({"open"})
+_LOCKED_VALUES = frozenset({"locked"})
+_UNLOCKED_VALUES = frozenset({"unlocked"})
 
 
-def _is_closed(status: str | None) -> bool | None:
-    """Interpret an open-state string: closed=True, open=False, unknown=None."""
-    if status is None:
+def _tristate(
+    value: str | None,
+    true_values: frozenset[str],
+    false_values: frozenset[str],
+) -> bool | None:
+    """Map a backend enum string to a tri-state bool (case-insensitive).
+
+    ``value`` in ``true_values`` -> True, in ``false_values`` -> False; ``None`` or an
+    unrecognised value -> None (never guessed).
+    """
+    if value is None:
         return None
-    lowered = status.lower()
-    if lowered in _CLOSED_VALUES:
+    lowered = value.lower()
+    if lowered in true_values:
         return True
-    if lowered in _OPEN_VALUES:
-        return False
-    return None
-
-
-def _is_locked(status: str | None) -> bool | None:
-    """Interpret a lock-state string: locked=True, unlocked=False, unknown=None."""
-    if status is None:
-        return None
-    lowered = status.lower()
-    if lowered == "locked":
-        return True
-    if lowered == "unlocked":
+    if lowered in false_values:
         return False
     return None
 
@@ -48,6 +46,16 @@ def _driver_on_left(status: RemoteStatusModel | None) -> bool:
     if status is None or status.left_hand_drive is None:
         return True
     return status.left_hand_drive
+
+
+def _rear_is_left(*, on_left: bool, driver_side: bool) -> bool:
+    """Whether a driver/passenger rear position maps to the physical rear-left slot.
+
+    The payload keys rear positions physically; the driver is on the left in an LHD
+    car. Shared by ``Doors`` and ``Windows`` so this left/right mapping — the
+    error-prone part — lives in one place.
+    """
+    return on_left if driver_side else not on_left
 
 
 class Door(CustomAPIBaseModel[Optional[DoorModel]]):
@@ -70,7 +78,7 @@ class Door(CustomAPIBaseModel[Optional[DoorModel]]):
         """If the door is closed."""
         if self._data is None or self._data.open_status is None:
             return None
-        return _is_closed(self._data.open_status.status)
+        return _tristate(self._data.open_status.status, _CLOSED_VALUES, _OPEN_VALUES)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -78,7 +86,9 @@ class Door(CustomAPIBaseModel[Optional[DoorModel]]):
         """If the door is locked."""
         if self._data is None or self._data.lock_status is None:
             return None
-        return _is_locked(self._data.lock_status.status)
+        return _tristate(
+            self._data.lock_status.status, _LOCKED_VALUES, _UNLOCKED_VALUES
+        )
 
 
 class Window(CustomAPIBaseModel[Optional[ComponentStateModel]]):
@@ -99,7 +109,9 @@ class Window(CustomAPIBaseModel[Optional[ComponentStateModel]]):
     @property
     def closed(self) -> bool | None:
         """Window closed state."""
-        return None if self._data is None else _is_closed(self._data.status)
+        if self._data is None:
+            return None
+        return _tristate(self._data.status, _CLOSED_VALUES, _OPEN_VALUES)
 
 
 class Doors(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
@@ -117,18 +129,14 @@ class Doors(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
         )
 
     def _rear(self, *, driver_side: bool) -> Door:
-        """Resolve a rear door by driver/passenger side via left_hand_drive.
-
-        The payload keys rear doors physically (rearLeft/rearRight); the driver
-        is on the left in an LHD car.
-        """
+        """Resolve a rear door by driver/passenger side via left_hand_drive."""
         doors = self._data.doors if self._data else None
         if doors is None:
             return Door(None)
-        on_left = _driver_on_left(self._data)
-        if driver_side:
-            return Door(doors.rear_left if on_left else doors.rear_right)
-        return Door(doors.rear_right if on_left else doors.rear_left)
+        left = _rear_is_left(
+            on_left=_driver_on_left(self._data), driver_side=driver_side
+        )
+        return Door(doors.rear_left if left else doors.rear_right)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -179,13 +187,14 @@ class Windows(CustomAPIBaseModel[Optional[RemoteStatusModel]]):
         )
 
     def _rear(self, *, driver_side: bool) -> Window:
+        """Resolve a rear window by driver/passenger side via left_hand_drive."""
         windows = self._data.windows if self._data else None
         if windows is None:
             return Window(None)
-        on_left = _driver_on_left(self._data)
-        if driver_side:
-            return Window(windows.rear_left if on_left else windows.rear_right)
-        return Window(windows.rear_right if on_left else windows.rear_left)
+        left = _rear_is_left(
+            on_left=_driver_on_left(self._data), driver_side=driver_side
+        )
+        return Window(windows.rear_left if left else windows.rear_right)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/pytoyoda/models/lock_status.py
+++ b/pytoyoda/models/lock_status.py
@@ -28,10 +28,10 @@ def _tristate(
 ) -> bool | None:
     """Map a backend enum string to a tri-state bool (case-insensitive).
 
-    ``value`` in ``true_values`` -> True, in ``false_values`` -> False; ``None`` or an
-    unrecognised value -> None (never guessed).
+    ``value`` in ``true_values`` -> True, in ``false_values`` -> False; ``None``, a
+    non-string, or an unrecognised value -> None (never guessed).
     """
-    if value is None:
+    if not isinstance(value, str):
         return None
     lowered = value.lower()
     if lowered in true_values:

--- a/tests/harness/mock_server.py
+++ b/tests/harness/mock_server.py
@@ -28,7 +28,6 @@ from typing import Any
 
 import jwt as pyjwt
 
-
 CERTS_DIR = Path(__file__).resolve().parent / "certs"
 CERT_PATH = CERTS_DIR / "cert.pem"
 KEY_PATH = CERTS_DIR / "key.pem"
@@ -249,12 +248,13 @@ def _build_status_response(sim: VehicleSim) -> bytes:
     """Render the /status fixture body but with the simulator's occurrence_date.
 
     We deep-copy lazily by re-loading the JSON each call (cheap; happens only on
-    cache-fresh hits) so we don't mutate _BODIES_CACHE."""
+    cache-fresh hits) so we don't mutate _BODIES_CACHE.
+    """
     raw = _load_real_or(
         "get_v1_global_remote_status.json", "v1_global_remote_status.json"
     )
     payload = raw.get("payload") or {}
-    payload["occurrenceDate"] = sim.occurrence_date()
+    payload["lastUpdateTimestamp"] = sim.occurrence_date()
     raw["payload"] = payload
     return json.dumps(raw).encode()
 
@@ -320,8 +320,9 @@ def _route(
             ).encode(),
         )
 
-    # GET /v1/global/remote/status (cache-expiry semantics)
-    if method == "GET" and "/v1/global/remote/status" in base_path:
+    # GET /v1/vehicle/status (cache-expiry semantics; migrated from
+    # /v1/global/remote/status which Toyota retired behind SigV4)
+    if method == "GET" and "/v1/vehicle/status" in base_path:
         vin = headers.get("vin") or headers.get("VIN") or "DEFAULT"
         sim = SIM.get(vin)
         sim.get_call_count += 1
@@ -355,7 +356,7 @@ def _route(
 class _Handler(BaseHTTPRequestHandler):
     """Minimal handler that silences default logging and dispatches on path."""
 
-    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003
+    def log_message(self, fmt: str, *args: Any) -> None:
         # Silent by default; stdlib http.server is very noisy otherwise.
         pass
 
@@ -372,13 +373,13 @@ class _Handler(BaseHTTPRequestHandler):
     def _request_headers(self) -> dict[str, str]:
         return {k: v for k, v in self.headers.items()}
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         status, headers, body = _route(
             "GET", self.path, headers=self._request_headers(), body_bytes=None
         )
         self._send(status, headers, body)
 
-    def do_POST(self) -> None:  # noqa: N802
+    def do_POST(self) -> None:
         length = int(self.headers.get("Content-Length", "0") or "0")
         body_bytes = self.rfile.read(length) if length > 0 else b""
         status, headers, body = _route(
@@ -437,5 +438,5 @@ class HarnessServer:
         self.start()
         return self
 
-    def __exit__(self, *exc_info: Any) -> None:
+    def __exit__(self, *exc_info: object) -> None:
         self.stop()

--- a/tests/harness/test_cache_expiry_contract.py
+++ b/tests/harness/test_cache_expiry_contract.py
@@ -12,7 +12,6 @@ Run via:
 
 from __future__ import annotations
 
-import json
 import ssl
 
 import httpx
@@ -21,7 +20,7 @@ import pytest
 from tests.harness.mock_server import SIM, HarnessServer
 
 
-@pytest.fixture()
+@pytest.fixture
 def server():
     SIM.reset()
     s = HarnessServer()
@@ -32,7 +31,7 @@ def server():
         s.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def client(server):
     # Mirror harness driver: trust the self-signed cert
     ctx = ssl.create_default_context()
@@ -43,7 +42,7 @@ def client(server):
 
 
 def _get_status(client, vin: str) -> httpx.Response:
-    return client.get("/v1/global/remote/status", headers={"vin": vin})
+    return client.get("/v1/vehicle/status", headers={"vin": vin})
 
 
 def _post_refresh(client, vin: str) -> httpx.Response:
@@ -76,7 +75,7 @@ def test_post_then_get_succeeds_when_responsive(client):
     assert post.json()["payload"]["returnCode"] == "000000"
     get = _get_status(client, "VIN-OK")
     assert get.status_code == 200
-    assert "occurrenceDate" in get.json()["payload"]
+    assert "lastUpdateTimestamp" in get.json()["payload"]
 
 
 def test_post_does_not_populate_when_unresponsive(client):
@@ -142,12 +141,12 @@ def test_call_counts_tracked(client):
     assert sim.get_call_count == 2
 
 
-def test_occurrence_date_is_iso8601_z(client):
-    """occurrenceDate is rendered with the trailing Z (matches real API shape)."""
+def test_last_update_timestamp_is_iso8601_z(client):
+    """LastUpdateTimestamp is rendered with the trailing Z (matches real API shape)."""
     SIM.configure("VIN-DATE", responsive=True)
     _post_refresh(client, "VIN-DATE")
     body = _get_status(client, "VIN-DATE").json()
-    occ = body["payload"]["occurrenceDate"]
+    occ = body["payload"]["lastUpdateTimestamp"]
     assert occ.endswith("Z")
     # Must be parseable by a simple consumer
     from datetime import datetime

--- a/tests/unit_tests/data/v1_global_remote_status.json
+++ b/tests/unit_tests/data/v1_global_remote_status.json
@@ -1,162 +1,114 @@
 {
   "status": {
+    "serviceIdentifier": "vehicle-status-service",
     "messages": [
       {
-        "responseCode": "ONE-GLOBAL-RS-10000",
-        "description": "Request Completed Successfully",
-        "detailedDescription": "Request Completed Successfully"
+        "responseCode": "CTP-GENERIC-20001",
+        "description": "Success",
+        "detailedDescription": "Request successfully completed"
       }
     ]
   },
   "payload": {
-    "vehicleStatus": [
-      {
-        "category": "carstatus_category_driver",
-        "displayOrder": 1,
-        "sections": [
-          {
-            "section": "carstatus_item_driver_door",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              },
-              {
-                "value": "carstatus_locked",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_driver_rear_door",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              },
-              {
-                "value": "carstatus_locked",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_driver_rear_window",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_driver_window",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              }
-            ]
-          }
-        ]
+    "vin": "SB1ZTEST0000000000",
+    "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+    "overallStatus": "ok",
+    "overallWarningCounts": 0,
+    "leftHandDrive": true,
+    "doors": {
+      "driver": {
+        "lockStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "locked"
+        },
+        "openStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "close"
+        }
       },
-      {
-        "category": "carstatus_category_passenger",
-        "displayOrder": 2,
-        "sections": [
-          {
-            "section": "carstatus_item_passenger_door",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              },
-              {
-                "value": "carstatus_locked",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_passenger_rear_door",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              },
-              {
-                "value": "carstatus_locked",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_passenger_rear_window",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_passenger_window",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              }
-            ]
-          }
-        ]
+      "passenger": {
+        "lockStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "locked"
+        },
+        "openStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "close"
+        }
       },
-      {
-        "category": "carstatus_category_other",
-        "displayOrder": 3,
-        "sections": [
-          {
-            "section": "carstatus_item_hood",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              }
-            ]
-          },
-          {
-            "section": "carstatus_item_rear_hatch",
-            "values": [
-              {
-                "value": "carstatus_closed",
-                "status": 0
-              },
-              {
-                "value": "carstatus_locked",
-                "status": 0
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "telemetry": {
-      "fugage": {
-        "value": 92.0,
-        "unit": "%"
+      "rearLeft": {
+        "lockStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "locked"
+        },
+        "openStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "close"
+        }
       },
-      "rage": {
-        "value": 588.0,
-        "unit": "Km"
+      "rearRight": {
+        "lockStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "locked"
+        },
+        "openStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "close"
+        }
       },
-      "odo": {
-        "value": 30444.0,
-        "unit": "Km"
+      "rearBack": {
+        "lockStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "locked"
+        },
+        "openStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "close"
+        }
+      },
+      "hood": {
+        "openStatus": {
+          "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+          "status": "close"
+        }
       }
     },
-    "occurrenceDate": "2023-11-30T10:18:21Z",
-    "cautionOverallCount": 0,
-    "latitude": 49.0,
-    "longitude": 8.0,
-    "locationAcquisitionDatetime": "2023-11-30T10:18:21Z"
+    "windows": {
+      "driver": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "close"
+      },
+      "passenger": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "close"
+      },
+      "rearLeft": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "close"
+      },
+      "rearRight": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "close"
+      }
+    },
+    "lights": {
+      "hazard": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "off"
+      },
+      "tail": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "off"
+      },
+      "head": {
+        "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+        "status": "off"
+      }
+    },
+    "rearSeatReminder": {
+      "lastUpdateTimestamp": "2026-06-30T20:29:07.000Z",
+      "warning": false,
+      "reason": "notDetected"
+    }
   }
 }

--- a/tests/unit_tests/test_models/test_lock_status.py
+++ b/tests/unit_tests/test_models/test_lock_status.py
@@ -1,256 +1,168 @@
 """Test lock_status Model."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
-from pytoyoda.models.endpoints.common import UnitValueModel
 from pytoyoda.models.endpoints.status import (
+    ComponentStateModel,
+    DoorModel,
+    DoorsModel,
     RemoteStatusModel,
     RemoteStatusResponseModel,
-    SectionModel,
-    VehicleStatusModel,
-    _TelemetryModel,
-    _ValueStatusModel,
+    WindowsModel,
 )
 from pytoyoda.models.lock_status import Door, Doors, LockStatus, Window, Windows
 
-# Mock data for testing
-mock_section_closed = SectionModel(
-    section="carstatus_item_driver_door",
-    values=[_ValueStatusModel(value="carstatus_closed", status=0)],
-)
-mock_section_locked = SectionModel(
-    section="carstatus_item_driver_door",
-    values=[_ValueStatusModel(value="carstatus_locked", status=0)],
-)
-mock_vehicle_status = VehicleStatusModel(
-    category="carstatus_category_driver",
-    sections=[mock_section_closed, mock_section_locked],
-    displayOrder=1,
-)
-mock_remote_status = RemoteStatusModel(
-    vehicleStatus=[mock_vehicle_status],
-    latitude=1.0,
-    longitude=1.0,
-    occurrenceDate=datetime.now().replace(second=0, microsecond=0),
-    locationAcquisitionDatetime=datetime.now().replace(second=0, microsecond=0),
-    cautionOverallCount=1,
-    telemetry=_TelemetryModel(
-        fugage=UnitValueModel(unit="bla", value=1.0),
-        rage=UnitValueModel(unit="bla", value=1.0),
-        odo=UnitValueModel(unit="bla", value=1.0),
-    ),
-)
-mock_remote_status_response = RemoteStatusResponseModel(
-    payload=mock_remote_status, status="OK", code=200, errors=[], message=None
-)
 
-
-# Parametrized test for Door.closed property
-@pytest.mark.parametrize(
-    "section, expected",
-    [
-        (None, None),  # No section provided
-        (mock_section_closed, True),  # Door is closed
-        (mock_section_locked, None),  # Status not related to closed
-    ],
-    ids=["no-section", "door-closed", "unrelated-status"],
-)
-def test_door_closed(section, expected):  # noqa: D103
-    # Arrange
-    door = Door(status=section)
-
-    # Act
-    result = door.closed
-
-    # Assert
-    assert result == expected
-
-
-# Parametrized test for Door.locked property
-@pytest.mark.parametrize(
-    "section, expected",
-    [
-        (None, None),  # No section provided
-        (mock_section_locked, True),  # Door is locked
-        (mock_section_closed, None),  # Status not related to locked
-    ],
-    ids=["no-section", "door-locked", "unrelated-status"],
-)
-def test_door_locked(section, expected):  # noqa: D103
-    # Arrange
-    door = Door(status=section)
-
-    # Act
-    result = door.locked
-
-    # Assert
-    assert result == expected
-
-
-# Parametrized test for Doors properties
-@pytest.mark.parametrize(
-    "category, section_name, property_name, expected_class",
-    [
-        (
-            "carstatus_category_driver",
-            "carstatus_item_driver_door",
-            "driver_seat",
-            Door,
-        ),
-        (
-            "carstatus_category_passenger",
-            "carstatus_item_passenger_door",
-            "passenger_seat",
-            Door,
-        ),
-        ("carstatus_category_other", "carstatus_item_rear_hatch", "trunk", Door),
-    ],
-    ids=["driver-seat", "passenger-seat", "trunk"],
-)
-def test_doors_properties(  # noqa : D103
-    category, section_name, property_name, expected_class
-):
-    # Arrange
-    status = RemoteStatusModel(
-        vehicleStatus=[
-            VehicleStatusModel(
-                category=category,
-                sections=[
-                    SectionModel(
-                        section=section_name,
-                        values=[_ValueStatusModel(value="carstatus_locked", status=0)],
-                    )
-                ],
-                displayOrder=1,
-            )
-        ],
-        latitude=1.0,
-        longitude=1.0,
-        occurrenceDate=datetime.now().replace(second=0, microsecond=0),
-        locationAcquisitionDatetime=datetime.now(),
-        cautionOverallCount=1,
-        telemetry=_TelemetryModel(
-            fugage=UnitValueModel(unit="bla", value=1.0),
-            rage=UnitValueModel(unit="bla", value=1.0),
-            odo=UnitValueModel(unit="bla", value=1.0),
-        ),
+def _door(lock: str | None = None, open_: str | None = None) -> DoorModel:
+    return DoorModel(
+        lockStatus=ComponentStateModel(status=lock) if lock is not None else None,
+        openStatus=ComponentStateModel(status=open_) if open_ is not None else None,
     )
 
-    # Act
+
+# --- Door.closed ------------------------------------------------------------
+@pytest.mark.parametrize(
+    "door_model, expected",
+    [
+        (None, None),
+        (_door(open_="close"), True),
+        (_door(open_="closed"), True),
+        (_door(open_="open"), False),
+        (_door(open_="wibble"), None),  # unknown enum -> None
+        (_door(lock="locked"), None),  # no open_status -> None
+    ],
+    ids=["none", "close", "closed", "open", "unknown", "no-open-status"],
+)
+def test_door_closed(door_model, expected):  # noqa: D103
+    assert Door(status=door_model).closed == expected
+
+
+# --- Door.locked ------------------------------------------------------------
+@pytest.mark.parametrize(
+    "door_model, expected",
+    [
+        (None, None),
+        (_door(lock="locked"), True),
+        (_door(lock="unlocked"), False),
+        (_door(lock="wibble"), None),  # unknown enum -> None
+        (_door(open_="close"), None),  # no lock_status -> None
+    ],
+    ids=["none", "locked", "unlocked", "unknown", "no-lock-status"],
+)
+def test_door_locked(door_model, expected):  # noqa: D103
+    assert Door(status=door_model).locked == expected
+
+
+# --- Doors accessors return Door for each position --------------------------
+@pytest.mark.parametrize(
+    "property_name",
+    ["driver_seat", "driver_rear_seat", "passenger_seat", "passenger_rear_seat", "trunk"],
+)
+def test_doors_properties(property_name):  # noqa: D103
+    status = RemoteStatusModel(
+        leftHandDrive=True,
+        doors=DoorsModel(
+            driver=_door(lock="locked"),
+            passenger=_door(lock="unlocked"),
+            rearLeft=_door(lock="locked"),
+            rearRight=_door(lock="unlocked"),
+            rearBack=_door(open_="close"),
+            hood=_door(open_="close"),
+        ),
+    )
+    assert isinstance(getattr(Doors(status=status), property_name), Door)
+
+
+# --- Rear door driver/passenger mapping honours left_hand_drive -------------
+@pytest.mark.parametrize(
+    "left_hand_drive, driver_rear_locked, passenger_rear_locked",
+    [
+        (True, True, False),  # LHD: driver=left(rearLeft locked), passenger=right(unlocked)
+        (False, False, True),  # RHD: driver=right(rearRight unlocked), passenger=left(locked)
+        (None, True, False),  # unknown -> defaults to LHD
+    ],
+    ids=["lhd", "rhd", "unknown-defaults-lhd"],
+)
+def test_rear_door_side_mapping(
+    left_hand_drive, driver_rear_locked, passenger_rear_locked
+):
+    status = RemoteStatusModel(
+        leftHandDrive=left_hand_drive,
+        doors=DoorsModel(
+            rearLeft=_door(lock="locked"),
+            rearRight=_door(lock="unlocked"),
+        ),
+    )
     doors = Doors(status=status)
-    result = getattr(doors, property_name)
-
-    # Assert
-    assert isinstance(result, expected_class)
+    assert doors.driver_rear_seat.locked is driver_rear_locked
+    assert doors.passenger_rear_seat.locked is passenger_rear_locked
 
 
-# Parametrized test for Window.closed property
+# --- Window.closed ----------------------------------------------------------
 @pytest.mark.parametrize(
-    "section, expected",
+    "window_model, expected",
     [
-        (None, None),  # No section provided
-        (mock_section_closed, True),  # Window is closed
+        (None, None),
+        (ComponentStateModel(status="close"), True),
+        (ComponentStateModel(status="open"), False),
     ],
-    ids=["no-section", "window-closed"],
+    ids=["none", "closed", "open"],
 )
-def test_window_closed(section, expected):  # noqa: D103
-    # Arrange
-    window = Window(status=section)
-
-    # Act
-    result = window.closed
-
-    # Assert
-    assert result == expected
+def test_window_closed(window_model, expected):  # noqa: D103
+    assert Window(status=window_model).closed == expected
 
 
-# Parametrized test for Windows properties
 @pytest.mark.parametrize(
-    "category, section_name, property_name, expected_class",
-    [
-        (
-            "carstatus_category_driver",
-            "carstatus_item_driver_window",
-            "driver_seat",
-            Window,
-        ),
-        (
-            "carstatus_category_passenger",
-            "carstatus_item_passenger_window",
-            "passenger_seat",
-            Window,
-        ),
-    ],
-    ids=["driver-seat-window", "passenger-seat-window"],
+    "property_name",
+    ["driver_seat", "driver_rear_seat", "passenger_seat", "passenger_rear_seat"],
 )
-def test_windows_properties(  # noqa : D103
-    category, section_name, property_name, expected_class
-):
-    # Arrange
+def test_windows_properties(property_name):  # noqa: D103
     status = RemoteStatusModel(
-        vehicleStatus=[
-            VehicleStatusModel(
-                category=category,
-                sections=[
-                    SectionModel(
-                        section=section_name,
-                        values=[_ValueStatusModel(value="carstatus_locked", status=0)],
-                    )
-                ],
-                displayOrder=1,
-            )
-        ],
-        latitude=1.0,
-        longitude=1.0,
-        occurrenceDate=datetime.now().replace(second=0, microsecond=0),
-        locationAcquisitionDatetime=datetime.now(),
-        cautionOverallCount=1,
-        telemetry=_TelemetryModel(
-            fugage=UnitValueModel(unit="bla", value=1.0),
-            rage=UnitValueModel(unit="bla", value=1.0),
-            odo=UnitValueModel(unit="bla", value=1.0),
+        leftHandDrive=True,
+        windows=WindowsModel(
+            driver=ComponentStateModel(status="close"),
+            passenger=ComponentStateModel(status="close"),
+            rearLeft=ComponentStateModel(status="close"),
+            rearRight=ComponentStateModel(status="open"),
         ),
     )
-
-    # Act
-    windows = Windows(status=status)
-    result = getattr(windows, property_name)
-
-    # Assert
-    assert isinstance(result, expected_class)
+    assert isinstance(getattr(Windows(status=status), property_name), Window)
 
 
-# Parametrized test for LockStatus properties
-@pytest.mark.parametrize(
-    "status, expected_last_updated, expected_doors_class, expected_windows_class",
-    [
-        (None, None, None, None),  # No status provided
-        (
-            mock_remote_status_response,
-            datetime.now().replace(second=0, microsecond=0),
-            Doors,
-            Windows,
-        ),  # Valid status
-    ],
-    ids=["no-status", "valid-status"],
-)
-def test_lock_status_properties(  # noqa : D103
-    status, expected_last_updated, expected_doors_class, expected_windows_class
-):
-    # Arrange
-    lock_status = LockStatus(status=status)
-
-    # Act & Assert
-    assert lock_status.last_updated == expected_last_updated
-    assert (
-        isinstance(lock_status.doors, expected_doors_class)
-        if expected_doors_class
-        else lock_status.doors is None
+# --- LockStatus -------------------------------------------------------------
+def _response(ts: datetime) -> RemoteStatusResponseModel:
+    return RemoteStatusResponseModel(
+        payload=RemoteStatusModel(
+            vin="TESTVIN",
+            lastUpdateTimestamp=ts,
+            leftHandDrive=True,
+            doors=DoorsModel(driver=_door(lock="locked", open_="close"), hood=_door(open_="close")),
+            windows=WindowsModel(driver=ComponentStateModel(status="close")),
+        ),
+        status="OK",
+        code=200,
+        errors=[],
+        message=None,
     )
-    assert (
-        isinstance(lock_status.windows, expected_windows_class)
-        if expected_windows_class
-        else lock_status.windows is None
-    )
+
+
+def test_lock_status_none():  # noqa: D103
+    lock_status = LockStatus(status=None)
+    assert lock_status.last_updated is None
+    assert lock_status.doors is None
+    assert lock_status.windows is None
+    assert lock_status.hood is None
+
+
+def test_lock_status_populated():  # noqa: D103
+    ts = datetime(2026, 6, 30, 20, 29, 7, tzinfo=timezone.utc)
+    lock_status = LockStatus(status=_response(ts))
+    assert lock_status.last_updated == ts  # occurrence_date alias -> lastUpdateTimestamp
+    assert isinstance(lock_status.doors, Doors)
+    assert isinstance(lock_status.windows, Windows)
+    assert lock_status.doors.driver_seat.locked is True
+    assert lock_status.doors.driver_seat.closed is True
+    assert lock_status.windows.driver_seat.closed is True
+    assert lock_status.hood.closed is True


### PR DESCRIPTION
## What

Migrate the vehicle status read from the retired `/v1/global/remote/status` to `/v1/vehicle/status`, replacing the old category/section/value status models with the new directly-typed payload.

## Why

Since ~26 Jun 2026 `/v1/global/remote/status` returns `403 APIGW-403` (`IncompleteSignatureException`) — Toyota moved that route behind AWS SigV4/IAM. The current MyToyota EU app (2.23.1) no longer calls it; it reads status from `/v1/vehicle/status` on the same host with the same plain `Bearer` + `x-api-key` we already send. So this is an **endpoint migration, not a signing problem** — no SigV4 needed.

Evidence:
- Static analysis of MyToyota EU 2.23.1: the app's HTTP client declares `GET /v1/vehicle/status` (plus `/v1/vehicle/climate-status`, `/v1/vehicle/climate-settings`); there is no `/v1/global/remote/status` read, and no AWS/SigV4/Cognito code anywhere in it.
- Live probe (same `Bearer` JWT on every route) against a Corolla Touring Sports: `/v1/global/remote/status` → 403, `/v1/vehicle/status` → 200.

## Changes

- `const`: `VEHICLE_GLOBAL_REMOTE_STATUS_ENDPOINT` → `/v1/vehicle/status`.
- `models/endpoints/status`: new directly-typed payload models (`DoorModel`/`DoorsModel`/`WindowsModel`/`ComponentStateModel`). `RemoteStatusModel`/`RemoteStatusResponseModel` names kept; `occurrence_date` retained as a back-compat property aliasing the new `lastUpdateTimestamp`.
- `models/lock_status`: read the typed model directly (drops `StatusHelper` and the `carstatus_*` magic strings). Physical `rearLeft`/`rearRight` → driver/passenger rear via `leftHandDrive`; tolerant of `UNKNOWN`/missing enum values. The rear side-mapping is factored into one `_rear_is_left()` helper (shared by doors + windows) and the open/lock parsing into one `_tristate()` helper.
- Only surfaces the payload we actually expose: the `lights` and `rearSeatReminder` sub-trees the endpoint also returns are **not** modelled here (no consumer) — they'll be typed alongside the sensor that reads them, so nothing ships as dead parse surface.
- tests + harness fixture updated to the new shape.

## Scope — where this sits in the wider migration

Only the **read** surface moved behind SigV4; remote commands are unaffected.

| function | pytoyoda now | new home | status |
|---|---|---|---|
| status | `/v1/global/remote/status` (403) | `/v1/vehicle/status` | ✅ this PR, verified 200 |
| climate reads | `/v1/global/remote/climate-*` (403) | `/v1/vehicle/climate-*` | #269 (probed 200) |
| climate control | `/v1/global/remote/climate-control` | `/v2/remote/climate-control` | follow-up |
| remote commands (lock/unlock/…) | `/v1/global/remote/command` | unchanged | not affected — still plain Bearer, verified working |

Kept surgical to the status read. Verified end-to-end against a live Corolla TS (`vehicle.update(only=["status"])` populates lock/doors/windows/hood, no 403). Unit suite green (127 passed); `ruff` clean.

Part of #267.

---

### The #267 migration, at a glance

Toyota fenced the whole `/v1/global/remote/*` family behind AWS SigV4 (→ `APIGW-403`); this series moves each surface onto the plain-Bearer routes the live MyToyota EU app (2.23.1) uses. **Four PRs, two independent chains:**

| PR | surface | route move | stacked on | breaking? |
|----|---------|-----------|-----------|-----------|
| #268 | status read | `…/remote/status` → `/v1/vehicle/status` | — | no |
| #270 | status wake | `POST …/remote/refresh-status` → `POST /v1/remote/status` | #268 | no |
| #269 | climate reads | `…/remote/climate-*` → `/v1/vehicle/climate-*` | — | yes ¹ |
| #271 | climate actuation | settings-PUT + control-POST → `POST /v2/remote/climate-control` | #269 | yes ² |

Suggested merge order: **#268 → #270** and **#269 → #271**; the two chains are independent and don't touch each other's files. Remote commands (lock/unlock/…) on `/v1/global/remote/command` are **not affected** — still plain Bearer, verified working.

¹ #269 reshapes the `ClimateStatus`/`ClimateSettings` accessors. ² #271 removes `update_climate_settings`. Both are detailed in their own PRs.
