### PR TITLE
fix(climate): read climate status/settings from /v1/vehicle/climate-* (part of #267)

### DIFF
--- a/pytoyoda/api.py
+++ b/pytoyoda/api.py
@@ -29,7 +29,7 @@ from pytoyoda.const import (
 from pytoyoda.controller import Controller
 from pytoyoda.models.endpoints.climate import (
     ClimateControlModel,
-    ClimateSettingsModel,
+    ClimateSettingsRequestModel,
     ClimateSettingsResponseModel,
     ClimateStatusResponseModel,
 )
@@ -341,8 +341,9 @@ class Api:
     async def get_climate_status(self, vin: str) -> ClimateStatusResponseModel:
         """Get the current climate control status.
 
-        Note: Only returns data if climate control is on. If off,
-        it returns status == 0 and all other fields are None.
+        Reads the server-cached climate state from /v1/vehicle/climate-status. When
+        climate is off the payload collapses to just ``{"status": "stopped"}``; the
+        temperature/duration/heating/seat fields populate while it is starting/running.
 
         Args:
             vin: Vehicle Identification Number
@@ -390,7 +391,7 @@ class Api:
         )
 
     async def update_climate_settings(
-        self, vin: str, settings: ClimateSettingsModel
+        self, vin: str, settings: ClimateSettingsRequestModel
     ) -> StatusModel:
         """Update the climate control settings for a vehicle.
 

--- a/pytoyoda/api.py
+++ b/pytoyoda/api.py
@@ -10,6 +10,7 @@ from pytoyoda.const import (
     VEHICLE_ASSOCIATION_ENDPOINT,
     VEHICLE_CLIMATE_CONTROL_ENDPOINT,
     VEHICLE_CLIMATE_SETTINGS_ENDPOINT,
+    VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT,
     VEHICLE_CLIMATE_STATUS_ENDPOINT,
     VEHICLE_CLIMATE_STATUS_REFRESH_ENDPOINT,
     VEHICLE_COMMAND_ENDPOINT,
@@ -406,7 +407,7 @@ class Api:
         return await self._request_and_parse(
             StatusModel,
             "PUT",
-            VEHICLE_CLIMATE_SETTINGS_ENDPOINT,
+            VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT,
             vin=vin,
             body=settings.model_dump(exclude_unset=True, by_alias=True),
         )

--- a/pytoyoda/const.py
+++ b/pytoyoda/const.py
@@ -28,10 +28,15 @@ VEHICLE_TELEMETRY_ENDPOINT = "/v3/telemetry"
 VEHICLE_NOTIFICATION_HISTORY_ENDPOINT = "/v2/notification/history"
 VEHICLE_TRIPS_ENDPOINT = "/v1/trips?from={from_date}&to={to_date}&route={route}&summary={summary}&limit={limit}&offset={offset}"  # noqa: E501
 VEHICLE_SERVICE_HISTORY_ENDPONT = "/v1/servicehistory/vehicle/summary"
+# Migrated 2026-07: Toyota retired the /v1/global/remote/climate-* read routes
+# (now behind AWS SigV4 -> APIGW-403). The live MyToyota app reads climate from
+# the plain-Bearer /v1/vehicle/climate-* namespace and wakes via /v1/remote/*.
+# Actuation (climate-control) moved to POST /v2/remote/climate-control with a new
+# body (V2RemoteClimateControlRequest) and is migrated separately.
 VEHICLE_CLIMATE_CONTROL_ENDPOINT = "/v1/global/remote/climate-control"
-VEHICLE_CLIMATE_SETTINGS_ENDPOINT = "/v1/global/remote/climate-settings"
-VEHICLE_CLIMATE_STATUS_ENDPOINT = "/v1/global/remote/climate-status"
-VEHICLE_CLIMATE_STATUS_REFRESH_ENDPOINT = "/v1/global/remote/refresh-climate-status"
+VEHICLE_CLIMATE_SETTINGS_ENDPOINT = "/v1/vehicle/climate-settings"
+VEHICLE_CLIMATE_STATUS_ENDPOINT = "/v1/vehicle/climate-status"
+VEHICLE_CLIMATE_STATUS_REFRESH_ENDPOINT = "/v1/remote/refresh-climate-status"
 VEHICLE_COMMAND_ENDPOINT = "/v1/global/remote/command"
 
 # Units

--- a/pytoyoda/const.py
+++ b/pytoyoda/const.py
@@ -31,10 +31,15 @@ VEHICLE_SERVICE_HISTORY_ENDPONT = "/v1/servicehistory/vehicle/summary"
 # Migrated 2026-07: Toyota retired the /v1/global/remote/climate-* read routes
 # (now behind AWS SigV4 -> APIGW-403). The live MyToyota app reads climate from
 # the plain-Bearer /v1/vehicle/climate-* namespace and wakes via /v1/remote/*.
-# Actuation (climate-control) moved to POST /v2/remote/climate-control with a new
+# Actuation (climate-control) moves to POST /v2/remote/climate-control with a new
 # body (V2RemoteClimateControlRequest) and is migrated separately.
 VEHICLE_CLIMATE_CONTROL_ENDPOINT = "/v1/global/remote/climate-control"
 VEHICLE_CLIMATE_SETTINGS_ENDPOINT = "/v1/vehicle/climate-settings"
+# The settings *write* (update_climate_settings) still targets the retired
+# /v1/global/remote route. That route is already SigV4-fenced, so the write is
+# non-functional regardless; it is removed with the actuation migration. Split from
+# the read const above so this change moves only the read.
+VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT = "/v1/global/remote/climate-settings"
 VEHICLE_CLIMATE_STATUS_ENDPOINT = "/v1/vehicle/climate-status"
 VEHICLE_CLIMATE_STATUS_REFRESH_ENDPOINT = "/v1/remote/refresh-climate-status"
 VEHICLE_COMMAND_ENDPOINT = "/v1/global/remote/command"

--- a/pytoyoda/models/climate.py
+++ b/pytoyoda/models/climate.py
@@ -23,15 +23,27 @@ from pytoyoda.utils.models import CustomAPIBaseModel, Temperature
 _CLIMATE_ON_STATES = frozenset({"starting", "running"})
 _CLIMATE_OFF_STATES = frozenset({"stopped", "stopping"})
 
+# Simple on/off heating toggles (front defroster, rear defogger, steering heater).
+_TOGGLE_ON_STATES = frozenset({"on"})
+_TOGGLE_OFF_STATES = frozenset({"off"})
 
-def _toggle_on(state: str | None) -> bool | None:
-    """Interpret an ``"off"``/``"on"`` toggle: on=True, off=False, unknown=None."""
-    if state is None:
+
+def _tristate(
+    value: str | None,
+    true_values: frozenset[str],
+    false_values: frozenset[str],
+) -> bool | None:
+    """Map a backend enum string to a tri-state bool (case-insensitive).
+
+    ``value`` in ``true_values`` -> True, in ``false_values`` -> False; ``None`` or an
+    unrecognised value -> None (never guessed).
+    """
+    if value is None:
         return None
-    normalized = state.lower()
-    if normalized == "on":
+    lowered = value.lower()
+    if lowered in true_values:
         return True
-    if normalized == "off":
+    if lowered in false_values:
         return False
     return None
 
@@ -53,19 +65,25 @@ class HeatingOptions(CustomAPIBaseModel[HeatingOptionsModel]):
     @property
     def front_defroster(self) -> bool | None:
         """Whether the front defroster is on."""
-        return _toggle_on(self._data.front_defroster) if self._data else None
+        return _tristate(
+            self._data.front_defroster, _TOGGLE_ON_STATES, _TOGGLE_OFF_STATES
+        )
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def rear_defogger(self) -> bool | None:
         """Whether the rear defogger is on."""
-        return _toggle_on(self._data.rear_defogger) if self._data else None
+        return _tristate(
+            self._data.rear_defogger, _TOGGLE_ON_STATES, _TOGGLE_OFF_STATES
+        )
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def steering_heater(self) -> bool | None:
         """Whether the steering-wheel heater is on."""
-        return _toggle_on(self._data.steering_heater) if self._data else None
+        return _tristate(
+            self._data.steering_heater, _TOGGLE_ON_STATES, _TOGGLE_OFF_STATES
+        )
 
 
 class SeatOptions(CustomAPIBaseModel[SeatOptionsModel]):
@@ -90,25 +108,25 @@ class SeatOptions(CustomAPIBaseModel[SeatOptionsModel]):
     @property
     def driver_seat(self) -> str | None:
         """Driver seat heater level."""
-        return self._data.driver_seat if self._data else None
+        return self._data.driver_seat
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def passenger_seat(self) -> str | None:
         """Front passenger seat heater level."""
-        return self._data.passenger_seat if self._data else None
+        return self._data.passenger_seat
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def rear_driver_seat(self) -> str | None:
         """Rear driver-side seat heater level."""
-        return self._data.rear_driver_seat if self._data else None
+        return self._data.rear_driver_seat
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def rear_passenger_seat(self) -> str | None:
         """Rear passenger-side seat heater level."""
-        return self._data.rear_passenger_seat if self._data else None
+        return self._data.rear_passenger_seat
 
 
 class ClimateStatus(CustomAPIBaseModel[ClimateStatusResponseModel]):
@@ -142,14 +160,8 @@ class ClimateStatus(CustomAPIBaseModel[ClimateStatusResponseModel]):
         ``starting``/``running`` -> True, ``stopped``/``stopping`` -> False, and an
         unknown or missing state -> None.
         """
-        if self._status is None or self._status.status is None:
-            return None
-        state = self._status.status.lower()
-        if state in _CLIMATE_ON_STATES:
-            return True
-        if state in _CLIMATE_OFF_STATES:
-            return False
-        return None
+        status = self._status.status if self._status else None
+        return _tristate(status, _CLIMATE_ON_STATES, _CLIMATE_OFF_STATES)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/pytoyoda/models/climate.py
+++ b/pytoyoda/models/climate.py
@@ -35,10 +35,10 @@ def _tristate(
 ) -> bool | None:
     """Map a backend enum string to a tri-state bool (case-insensitive).
 
-    ``value`` in ``true_values`` -> True, in ``false_values`` -> False; ``None`` or an
-    unrecognised value -> None (never guessed).
+    ``value`` in ``true_values`` -> True, in ``false_values`` -> False; ``None``, a
+    non-string, or an unrecognised value -> None (never guessed).
     """
-    if value is None:
+    if not isinstance(value, str):
         return None
     lowered = value.lower()
     if lowered in true_values:

--- a/pytoyoda/models/climate.py
+++ b/pytoyoda/models/climate.py
@@ -1,294 +1,202 @@
-"""Climate Settings Models."""
+"""Climate Status and Settings Models.
+
+Public wrappers over the ``/v1/vehicle/climate-status`` and
+``/v1/vehicle/climate-settings`` read endpoints.
+"""
 
 from datetime import datetime, timedelta
 
 from pydantic import computed_field
 
 from pytoyoda.models.endpoints.climate import (
-    ACOperations,
-    ACParameters,
-    ClimateOptions,
     ClimateSettingsModel,
     ClimateSettingsResponseModel,
-    ClimateStatusModel,
+    ClimateStatusResponseModel,
+    HeatingOptionsModel,
+    SeatOptionsModel,
 )
 from pytoyoda.utils.models import CustomAPIBaseModel, Temperature
 
+# Backend climate-status enum (RemoteClimateStatus$Status backendKeys). ``starting``
+# and ``stopping`` are transitional; on/off is decided by intent, and an unrecognised
+# value maps to None rather than being guessed.
+_CLIMATE_ON_STATES = frozenset({"starting", "running"})
+_CLIMATE_OFF_STATES = frozenset({"stopped", "stopping"})
 
-class ClimateOptionStatus(CustomAPIBaseModel[ClimateOptions]):
-    """Climate option status."""
 
-    def __init__(self, options: ClimateOptions, **kwargs: dict) -> None:
-        """Initialize climate option status.
+def _toggle_on(state: str | None) -> bool | None:
+    """Interpret an ``"off"``/``"on"`` toggle: on=True, off=False, unknown=None."""
+    if state is None:
+        return None
+    return state.lower() == "on"
+
+
+class HeatingOptions(CustomAPIBaseModel[HeatingOptionsModel]):
+    """Defroster / defogger / steering-heater states."""
+
+    def __init__(self, options: HeatingOptionsModel, **kwargs: dict) -> None:
+        """Initialize heating options.
 
         Args:
-            options (ClimateOptions): Contains all additional options for climate
-            **kwargs: Additional keyword arguments passed to the parent class
+            options (HeatingOptionsModel): The heating option states.
+            **kwargs: Additional keyword arguments passed to the parent class.
 
         """
         super().__init__(data=options, **kwargs)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def front_defogger(self) -> bool:
-        """The front defogger status.
-
-        Returns:
-            bool: The status of front defogger
-
-        """
-        return self._data.front_defogger
+    def front_defroster(self) -> bool | None:
+        """Whether the front defroster is on."""
+        return _toggle_on(self._data.front_defroster) if self._data else None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def rear_defogger(self) -> bool:
-        """The rear defogger status.
+    def rear_defogger(self) -> bool | None:
+        """Whether the rear defogger is on."""
+        return _toggle_on(self._data.rear_defogger) if self._data else None
 
-        Returns:
-            bool: The status of rear defogger
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def steering_heater(self) -> bool | None:
+        """Whether the steering-wheel heater is on."""
+        return _toggle_on(self._data.steering_heater) if self._data else None
+
+
+class SeatOptions(CustomAPIBaseModel[SeatOptionsModel]):
+    """Per-seat heater levels.
+
+    Values are the raw backend level strings (``"off"``/``"low"``/``"medium"``/
+    ``"high"``) — kept as-is rather than coerced to bool because seat heaters are
+    multi-level.
+    """
+
+    def __init__(self, options: SeatOptionsModel, **kwargs: dict) -> None:
+        """Initialize seat options.
+
+        Args:
+            options (SeatOptionsModel): The per-seat heater levels.
+            **kwargs: Additional keyword arguments passed to the parent class.
 
         """
-        return self._data.rear_defogger
+        super().__init__(data=options, **kwargs)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def driver_seat(self) -> str | None:
+        """Driver seat heater level."""
+        return self._data.driver_seat if self._data else None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def passenger_seat(self) -> str | None:
+        """Front passenger seat heater level."""
+        return self._data.passenger_seat if self._data else None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def rear_driver_seat(self) -> str | None:
+        """Rear driver-side seat heater level."""
+        return self._data.rear_driver_seat if self._data else None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def rear_passenger_seat(self) -> str | None:
+        """Rear passenger-side seat heater level."""
+        return self._data.rear_passenger_seat if self._data else None
 
 
-class ClimateStatus(CustomAPIBaseModel[ClimateStatusModel]):
+class ClimateStatus(CustomAPIBaseModel[ClimateStatusResponseModel]):
     """Climate status."""
 
-    def __init__(self, climate_status: ClimateStatusModel, **kwargs: dict) -> None:
+    def __init__(
+        self, climate_status: ClimateStatusResponseModel, **kwargs: dict
+    ) -> None:
         """Initialize climate status.
 
         Args:
-            climate_status (ClimateStatusModel): Contains all information
-              regarding the climate status
-            **kwargs: Additional keyword arguments passed to the parent class
+            climate_status (ClimateStatusResponseModel): The climate-status response
+                envelope; the typed payload is unwrapped here.
+            **kwargs: Additional keyword arguments passed to the parent class.
 
         """
         super().__init__(data=climate_status, **kwargs)
+        self._status = self._data.payload if self._data else None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def type(self) -> str | None:
-        """The type.
-
-        Returns:
-            Optional[str]: The type, or None if unavailable
-
-        """
-        return self._data.type if self._data else None
+    def status(self) -> str | None:
+        """Raw backend state (``stopped``/``starting``/``stopping``/``running``)."""
+        return self._status.status if self._status else None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def status(self) -> bool:
-        """The status.
+    def is_on(self) -> bool | None:
+        """Whether climate is engaged.
 
-        Returns:
-            bool: The status
-
+        ``starting``/``running`` -> True, ``stopped``/``stopping`` -> False, and an
+        unknown or missing state -> None.
         """
-        return self._data.status
+        if self._status is None or self._status.status is None:
+            return None
+        state = self._status.status.lower()
+        if state in _CLIMATE_ON_STATES:
+            return True
+        if state in _CLIMATE_OFF_STATES:
+            return False
+        return None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def start_time(self) -> datetime | None:
-        """Start time.
+    def started_at(self) -> datetime | None:
+        """When the current climate run started."""
+        return self._status.started_at if self._status else None
 
-        Returns:
-            datetime: Start time
-
-        """
-        return self._data.started_at
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def updated_at(self) -> datetime | None:
+        """When the backend last refreshed this state."""
+        return self._status.updated_at if self._status else None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def duration(self) -> timedelta | None:
-        """The duration.
-
-        Returns:
-            timedelta: The duration
-
-        """
-        if self._data.duration is None:
+        """Programmed run duration."""
+        if self._status is None or self._status.duration is None:
             return None
-
-        return timedelta(seconds=self._data.duration)
+        return timedelta(minutes=self._status.duration)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def current_temperature(self) -> Temperature | None:
-        """The current temperature.
-
-        Returns:
-            Temperature: The current temperature with unit
-
-        """
-        if self._data.current_temperature is None:
+        """Measured cabin temperature."""
+        temp = self._status.current_temperature if self._status else None
+        if temp is None:
             return None
-
-        return Temperature(
-            value=self._data.current_temperature.value,
-            unit=self._data.current_temperature.unit,
-        )
+        return Temperature(value=temp.value, unit=temp.unit)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def target_temperature(self) -> Temperature | None:
-        """The target temperature.
-
-        Returns:
-            Temperature: The target temperature with unit
-
-        """
-        if self._data.target_temperature is None:
+        """Target temperature."""
+        temp = self._status.target_temperature if self._status else None
+        if temp is None:
             return None
-
-        return Temperature(
-            value=self._data.target_temperature.value,
-            unit=self._data.target_temperature.unit,
-        )
+        return Temperature(value=temp.value, unit=temp.unit)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def options(self) -> ClimateOptionStatus | None:
-        """The status of climate options.
-
-        Returns:
-            ClimateOptionsStatus: The statuses of climate options
-
-        """
-        if self._data.options is None:
-            return None
-
-        return ClimateOptionStatus(options=self._data.options)
-
-
-class ClimateSettingsParameter(CustomAPIBaseModel[ACParameters]):
-    """Climate settings parameter."""
-
-    def __init__(self, parameter: ACParameters, **kwargs: dict) -> None:
-        """Initialize climate settings parameter.
-
-        Args:
-            parameter (ACParameters): Contains all parameters
-            **kwargs: Additional keyword arguments passed to the parent class
-
-        """
-        super().__init__(data=parameter, **kwargs)
+    def heating_options(self) -> HeatingOptions | None:
+        """Defroster / defogger / steering-heater states."""
+        options = self._status.heating_options if self._status else None
+        return HeatingOptions(options) if options is not None else None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def available(self) -> bool | None:
-        """The parameter availability.
-
-        Returns:
-            bool: The parameter availability value
-
-        """
-        return self._data.available
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def enabled(self) -> bool:
-        """The parameter enable.
-
-        Returns:
-            bool: The parameter enable value
-
-        """
-        return self._data.enabled
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def display_name(self) -> str | None:
-        """The parameter display name.
-
-        Returns:
-            str: The parameter display name
-
-        """
-        return self._data.display_name
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def name(self) -> str:
-        """The parameter name.
-
-        Returns:
-            str: The parameter name
-
-        """
-        return self._data.name
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def icon_url(self) -> str | None:
-        """The parameter icon url.
-
-        Returns:
-            str: The parameter icon url
-
-        """
-        return self._data.icon_url
-
-
-class ClimateSettingsOperation(CustomAPIBaseModel[ACOperations]):
-    """Climate settings operation."""
-
-    def __init__(self, operations: ACOperations, **kwargs: dict) -> None:
-        """Initialize climate settings operation.
-
-        Args:
-            operations (ACOperations): Contains all options for climate
-            **kwargs: Additional keyword arguments passed to the parent class
-
-        """
-        super().__init__(data=operations, **kwargs)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def available(self) -> bool | None:
-        """The operation availability.
-
-        Returns:
-            bool: The operation availability value
-
-        """
-        return self._data.available
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def category_name(self) -> str:
-        """The operation category name.
-
-        Returns:
-            str: The operation category name
-
-        """
-        return self._data.category_name
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def category_display_name(self) -> str | None:
-        """The operation category display name.
-
-        Returns:
-            str: The operation category display name
-
-        """
-        return self._data.category_display_name
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def parameters(self) -> list[ClimateSettingsParameter] | None:
-        """The operation parameter.
-
-        Returns:
-            list[ClimateSettingsParameter]: The operation parameter
-
-        """
-        if self._data.ac_parameters is None:
-            return None
-
-        return [ClimateSettingsParameter(parameter=p) for p in self._data.ac_parameters]
+    def seat_options(self) -> SeatOptions | None:
+        """Per-seat heater levels."""
+        options = self._status.seat_options if self._status else None
+        return SeatOptions(options) if options is not None else None
 
 
 class ClimateSettings(CustomAPIBaseModel[ClimateSettingsResponseModel]):
@@ -300,92 +208,78 @@ class ClimateSettings(CustomAPIBaseModel[ClimateSettingsResponseModel]):
         """Initialize climate settings.
 
         Args:
-            climate_settings (ClimateSettingsResponseModel): Contains all information
-                regarding the climate settings
-            **kwargs: Additional keyword arguments passed to the parent class
+            climate_settings (ClimateSettingsResponseModel): The climate-settings
+                response envelope; the typed payload is unwrapped here.
+            **kwargs: Additional keyword arguments passed to the parent class.
 
         """
         super().__init__(data=climate_settings, **kwargs)
-        self._climate_settings: ClimateSettingsModel | None = (
+        self._settings: ClimateSettingsModel | None = (
             self._data.payload if self._data else None
         )
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def settings_on(self) -> bool | None:
-        """The settings on value.
-
-        Returns:
-            bool: The value of settings on
-
-        """
-        return self._climate_settings.settings_on if self._climate_settings else None
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def temp_interval(self) -> float | None:
-        """The temperature interval.
-
-        Returns:
-            float: The value of temperature interval
-
-        """
-        return self._climate_settings.temp_interval if self._climate_settings else None
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def min_temp(self) -> float | None:
-        """The min temperature.
-
-        Returns:
-            float: The value of min temperature
-
-        """
-        return self._climate_settings.min_temp if self._climate_settings else None
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def max_temp(self) -> float | None:
-        """The max temperature.
-
-        Returns:
-            float: The value of max temperature
-
-        """
-        return self._climate_settings.max_temp if self._climate_settings else None
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
     def temperature(self) -> Temperature | None:
-        """The temperature.
+        """Target temperature."""
+        temp = self._settings.temperature if self._settings else None
+        if temp is None:
+            return None
+        return Temperature(value=temp.value, unit=temp.unit)
 
-        Returns:
-            Temperature: The temperature with unit
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def duration(self) -> timedelta | None:
+        """Programmed run duration."""
+        if self._settings is None or self._settings.duration is None:
+            return None
+        return timedelta(minutes=self._settings.duration)
 
-        """
-        if self._climate_settings:
-            return Temperature(
-                value=self._climate_settings.temperature,
-                unit=self._climate_settings.temperature_unit,
-            )
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def heating_options(self) -> HeatingOptions | None:
+        """Defroster / defogger / steering-heater settings."""
+        options = self._settings.heating_options if self._settings else None
+        return HeatingOptions(options) if options is not None else None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def seat_options(self) -> SeatOptions | None:
+        """Per-seat heater level settings."""
+        options = self._settings.seat_options if self._settings else None
+        return SeatOptions(options) if options is not None else None
+
+    # --- Deprecated back-compat accessors -----------------------------------
+    # The new /v1/vehicle/climate-settings payload no longer carries these. They
+    # are kept (returning None/[]) so external consumers of the old shape do not
+    # break; new code should read temperature/duration/heating_options/seat_options.
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def settings_on(self) -> None:
+        """Deprecated: removed from the new climate-settings payload."""
         return None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def operations(self) -> list[ClimateSettingsOperation] | None:
-        """The climate operation settings.
+    def min_temp(self) -> None:
+        """Deprecated: removed from the new climate-settings payload."""
+        return None
 
-        Returns:
-            list[ClimateSettingsOperation]: The settings of climate operation
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def max_temp(self) -> None:
+        """Deprecated: removed from the new climate-settings payload."""
+        return None
 
-        """
-        if (
-            self._climate_settings is None
-            or self._climate_settings.ac_operations is None
-        ):
-            return None
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def temp_interval(self) -> None:
+        """Deprecated: removed from the new climate-settings payload."""
+        return None
 
-        return [
-            ClimateSettingsOperation(operations=p)
-            for p in self._climate_settings.ac_operations
-        ]
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def operations(self) -> list:
+        """Deprecated: acOperations no longer exist in the new payload."""
+        return []

--- a/pytoyoda/models/climate.py
+++ b/pytoyoda/models/climate.py
@@ -28,7 +28,12 @@ def _toggle_on(state: str | None) -> bool | None:
     """Interpret an ``"off"``/``"on"`` toggle: on=True, off=False, unknown=None."""
     if state is None:
         return None
-    return state.lower() == "on"
+    normalized = state.lower()
+    if normalized == "on":
+        return True
+    if normalized == "off":
+        return False
+    return None
 
 
 class HeatingOptions(CustomAPIBaseModel[HeatingOptionsModel]):

--- a/pytoyoda/models/endpoints/climate.py
+++ b/pytoyoda/models/endpoints/climate.py
@@ -1,4 +1,20 @@
-"""Toyota Connected Services API - Climate Models."""
+"""Toyota Connected Services API - Climate Models.
+
+Read models for the ``/v1/vehicle/climate-status`` and ``/v1/vehicle/climate-settings``
+endpoints. Toyota retired the previous ``/v1/global/remote/climate-*`` read routes in
+mid-2026 (they now sit behind AWS SigV4 and return ``APIGW-403``); the live app moved to
+the plain-Bearer ``/v1/vehicle/*`` namespace, whose payloads are directly typed and much
+smaller than the old ``acOperations``/min-max settings blob.
+
+Every field is optional: the off-state climate-status payload collapses to just
+``{"status": "stopped"}``, and the remaining fields populate only while climate is
+starting/running.
+
+``ClimateSettingsRequestModel`` and ``ClimateControlModel`` remain the *legacy write
+bodies* used by the not-yet-migrated actuation path (settings PUT / control POST). The
+read models below no longer share their shape — actuation is moving to
+``POST /v2/remote/climate-control`` (``V2RemoteClimateControlRequest``) in a follow-up.
+"""
 
 from datetime import datetime
 
@@ -8,8 +24,96 @@ from pytoyoda.models.endpoints.common import StatusModel, UnitValueModel
 from pytoyoda.utils.models import CustomEndpointBaseModel
 
 
+class HeatingOptionsModel(CustomEndpointBaseModel):
+    """Heating toggles (each ``"off"``/``"on"``).
+
+    Attributes:
+        front_defroster: Front windscreen defroster state.
+        rear_defogger: Rear window defogger state.
+        steering_heater: Steering-wheel heater state.
+
+    """
+
+    front_defroster: str | None = Field(alias="frontDefroster", default=None)
+    rear_defogger: str | None = Field(alias="rearDefogger", default=None)
+    steering_heater: str | None = Field(alias="steeringHeater", default=None)
+
+
+class SeatOptionsModel(CustomEndpointBaseModel):
+    """Seat-heater levels (each ``"off"``/``"low"``/``"medium"``/``"high"``).
+
+    Attributes:
+        driver_seat: Driver seat heater level.
+        passenger_seat: Front passenger seat heater level.
+        rear_driver_seat: Rear driver-side seat heater level.
+        rear_passenger_seat: Rear passenger-side seat heater level.
+
+    """
+
+    driver_seat: str | None = Field(alias="driverSeat", default=None)
+    passenger_seat: str | None = Field(alias="passengerSeat", default=None)
+    rear_driver_seat: str | None = Field(alias="rearDriverSeat", default=None)
+    rear_passenger_seat: str | None = Field(alias="rearPassengerSeat", default=None)
+
+
+class ClimateStatusModel(CustomEndpointBaseModel):
+    """``/v1/vehicle/climate-status`` payload.
+
+    Off-state collapses to just ``status`` (e.g. ``"stopped"``); the remaining fields
+    populate while climate is starting/running.
+
+    Attributes:
+        status: Backend state enum ``stopped``/``starting``/``stopping``/``running``.
+        started_at: When the current climate run started.
+        updated_at: When the backend last refreshed this state.
+        duration: Programmed run duration, in minutes.
+        current_temperature: Measured cabin temperature (value + unit).
+        target_temperature: Target temperature (value + unit).
+        heating_options: Defroster/defogger/steering-heater states.
+        seat_options: Per-seat heater levels.
+
+    """
+
+    status: str | None = None
+    started_at: datetime | None = Field(alias="startedAt", default=None)
+    updated_at: datetime | None = Field(alias="updatedAt", default=None)
+    duration: int | None = None
+    current_temperature: UnitValueModel | None = Field(
+        alias="currentTemperature", default=None
+    )
+    target_temperature: UnitValueModel | None = Field(
+        alias="targetTemperature", default=None
+    )
+    heating_options: HeatingOptionsModel | None = Field(
+        alias="heatingOptions", default=None
+    )
+    seat_options: SeatOptionsModel | None = Field(alias="seatOptions", default=None)
+
+
+class ClimateSettingsModel(CustomEndpointBaseModel):
+    """``/v1/vehicle/climate-settings`` payload.
+
+    Attributes:
+        duration: Programmed run duration, in minutes.
+        temperature: Target temperature (value + unit).
+        heating_options: Defroster/defogger/steering-heater settings.
+        seat_options: Per-seat heater level settings.
+
+    """
+
+    duration: int | None = None
+    temperature: UnitValueModel | None = None
+    heating_options: HeatingOptionsModel | None = Field(
+        alias="heatingOptions", default=None
+    )
+    seat_options: SeatOptionsModel | None = Field(alias="seatOptions", default=None)
+
+
+# --- Legacy write bodies (actuation not yet migrated to /v2/remote/climate-control) ---
+
+
 class ACParameters(CustomEndpointBaseModel):
-    """Model representing parameters for AC.
+    """Legacy AC parameter (write body).
 
     Attributes:
         available: Whether the AC parameter is available
@@ -28,7 +132,7 @@ class ACParameters(CustomEndpointBaseModel):
 
 
 class ACOperations(CustomEndpointBaseModel):
-    """Model representing AC operations.
+    """Legacy AC operation (write body).
 
     Attributes:
         available: Whether the operation is available
@@ -46,78 +150,24 @@ class ACOperations(CustomEndpointBaseModel):
     )
 
 
-class ClimateSettingsModel(CustomEndpointBaseModel):
-    """Model representing climate settings.
+class ClimateSettingsRequestModel(CustomEndpointBaseModel):
+    """Legacy climate-settings write body (``PUT`` climate-settings).
+
+    Superseded by the unified ``POST /v2/remote/climate-control`` request; kept so the
+    not-yet-migrated actuation path continues to type-check.
 
     Attributes:
-        ac_operations: List of available AC operations
-        max_temp: Maximum allowable temperature
-        min_temp: Minimum allowable temperature
+        ac_operations: List of AC operations to apply
         settings_on: Whether climate settings are active
-        temp_interval: Temperature increment for controls
-        temperature: Current target temperature
+        temperature: Target temperature
         temperature_unit: Unit of temperature (C or F)
 
     """
 
     ac_operations: list[ACOperations] | None = Field(alias="acOperations", default=None)
-    max_temp: float | None = Field(alias="maxTemp", default=None)
-    min_temp: float | None = Field(alias="minTemp", default=None)
-    settings_on: bool = Field(alias="settingsOn")
-    temp_interval: float | None = Field(alias="tempInterval", default=None)
-    temperature: float
-    temperature_unit: str = Field(alias="temperatureUnit")
-
-
-class CurrentTemperature(UnitValueModel):
-    """Model representing current temperature.
-
-    Attributes:
-        timestamp: When the temperature was recorded
-
-    """
-
-    timestamp: datetime
-
-
-class ClimateOptions(CustomEndpointBaseModel):
-    """Model representing climate options.
-
-    Attributes:
-        front_defogger: Whether front defogger is active
-        rear_defogger: Whether rear defogger is active
-
-    """
-
-    front_defogger: bool = Field(alias="frontDefogger")
-    rear_defogger: bool = Field(alias="rearDefogger")
-
-
-class ClimateStatusModel(CustomEndpointBaseModel):
-    """Model representing climate status.
-
-    Attributes:
-        current_temperature: Currently measured temperature
-        duration: Duration in minutes for operation
-        options: Additional climate options
-        started_at: When climate control was started
-        status: Whether climate control is active
-        target_temperature: Desired temperature
-        type: Type of climate control mode
-
-    """
-
-    current_temperature: CurrentTemperature | None = Field(
-        alias="currentTemperature", default=None
-    )
-    duration: int | None = None
-    options: ClimateOptions | None = None
-    started_at: datetime | None = Field(alias="startedAt", default=None)
-    status: bool
-    target_temperature: UnitValueModel | None = Field(
-        alias="targetTemperature", default=None
-    )
-    type: str
+    settings_on: bool | None = Field(alias="settingsOn", default=None)
+    temperature: float | None = None
+    temperature_unit: str | None = Field(alias="temperatureUnit", default=None)
 
 
 class RemoteHVACModel(CustomEndpointBaseModel):
@@ -132,10 +182,10 @@ class RemoteHVACModel(CustomEndpointBaseModel):
 
 
 class ClimateControlModel(CustomEndpointBaseModel):
-    """Model representing climate control commands.
+    """Legacy climate control command body.
 
     Attributes:
-        command: Command to execute (e.g., "start", "stop")
+        command: Command to execute (e.g., "engine-start", "engine-stop")
         remote_hvac: Additional HVAC settings if applicable
 
     """

--- a/tests/harness/mock_server.py
+++ b/tests/harness/mock_server.py
@@ -28,7 +28,6 @@ from typing import Any
 
 import jwt as pyjwt
 
-
 CERTS_DIR = Path(__file__).resolve().parent / "certs"
 CERT_PATH = CERTS_DIR / "cert.pem"
 KEY_PATH = CERTS_DIR / "key.pem"
@@ -104,8 +103,25 @@ def _bodies() -> dict[str, Any]:
         "service_history": _load_real_or(
             "get_v1_servicehistory_vehicle_summary.json", "v1_service_history.json"
         ),
-        "climate_status": {"payload": None, "status": {"messages": []}},
-        "climate_settings": {"payload": None, "status": {"messages": []}},
+        "climate_status": {"payload": {"status": "stopped"}, "status": {"messages": []}},
+        "climate_settings": {
+            "payload": {
+                "duration": 20,
+                "temperature": {"value": 18.0, "unit": "C"},
+                "heatingOptions": {
+                    "frontDefroster": "off",
+                    "rearDefogger": "off",
+                    "steeringHeater": "off",
+                },
+                "seatOptions": {
+                    "driverSeat": "off",
+                    "passengerSeat": "off",
+                    "rearDriverSeat": "off",
+                    "rearPassengerSeat": "off",
+                },
+            },
+            "status": {"messages": []},
+        },
         "trips": _load_real_or("get_v1_trips.json", "v1_trips.json"),
     }
 
@@ -249,7 +265,8 @@ def _build_status_response(sim: VehicleSim) -> bytes:
     """Render the /status fixture body but with the simulator's occurrence_date.
 
     We deep-copy lazily by re-loading the JSON each call (cheap; happens only on
-    cache-fresh hits) so we don't mutate _BODIES_CACHE."""
+    cache-fresh hits) so we don't mutate _BODIES_CACHE.
+    """
     raw = _load_real_or(
         "get_v1_global_remote_status.json", "v1_global_remote_status.json"
     )
@@ -338,8 +355,8 @@ def _route(
         ("/v1/location", "location"),
         ("/v1/vehiclehealth/status", "health"),
         ("/v1/global/remote/electric/status", "electric"),
-        ("/v1/global/remote/climate-status", "climate_status"),
-        ("/v1/global/remote/climate-settings", "climate_settings"),
+        ("/v1/vehicle/climate-status", "climate_status"),
+        ("/v1/vehicle/climate-settings", "climate_settings"),
         ("/v3/telemetry", "telemetry"),
         ("/v2/notification/history", "notifications"),
         ("/v1/servicehistory", "service_history"),
@@ -355,7 +372,7 @@ def _route(
 class _Handler(BaseHTTPRequestHandler):
     """Minimal handler that silences default logging and dispatches on path."""
 
-    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003
+    def log_message(self, fmt: str, *args: Any) -> None:
         # Silent by default; stdlib http.server is very noisy otherwise.
         pass
 
@@ -372,13 +389,13 @@ class _Handler(BaseHTTPRequestHandler):
     def _request_headers(self) -> dict[str, str]:
         return {k: v for k, v in self.headers.items()}
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         status, headers, body = _route(
             "GET", self.path, headers=self._request_headers(), body_bytes=None
         )
         self._send(status, headers, body)
 
-    def do_POST(self) -> None:  # noqa: N802
+    def do_POST(self) -> None:
         length = int(self.headers.get("Content-Length", "0") or "0")
         body_bytes = self.rfile.read(length) if length > 0 else b""
         status, headers, body = _route(
@@ -437,5 +454,5 @@ class HarnessServer:
         self.start()
         return self
 
-    def __exit__(self, *exc_info: Any) -> None:
+    def __exit__(self, *exc_info: object) -> None:
         self.stop()

--- a/tests/harness/mocks.py
+++ b/tests/harness/mocks.py
@@ -9,15 +9,12 @@ to reproduce (or rule out) the memory leak.
 from __future__ import annotations
 
 import json
-import time
-import uuid
 from pathlib import Path
 from typing import Any
 
 import httpx
 import jwt as pyjwt
 import respx
-
 
 TOKEN_EXPIRY_SECONDS = 1800
 
@@ -66,8 +63,25 @@ def _response_bodies() -> dict[str, Any]:
         "telemetry": _load_fixture("v3_telemetry.json"),
         "notifications": _load_fixture("v2_notification.json"),
         "service_history": _load_fixture("v1_service_history.json"),
-        "climate_status": {"payload": None, "status": {"messages": []}},
-        "climate_settings": {"payload": None, "status": {"messages": []}},
+        "climate_status": {"payload": {"status": "stopped"}, "status": {"messages": []}},
+        "climate_settings": {
+            "payload": {
+                "duration": 20,
+                "temperature": {"value": 18.0, "unit": "C"},
+                "heatingOptions": {
+                    "frontDefroster": "off",
+                    "rearDefogger": "off",
+                    "steeringHeater": "off",
+                },
+                "seatOptions": {
+                    "driverSeat": "off",
+                    "passengerSeat": "off",
+                    "rearDriverSeat": "off",
+                    "rearPassengerSeat": "off",
+                },
+            },
+            "status": {"messages": []},
+        },
         "trips": _load_fixture("v1_trips.json"),
     }
 
@@ -104,10 +118,10 @@ def register_all(router: respx.Router) -> None:
     router.get(url__regex=r".*/v1/global/remote/electric/status.*").mock(
         return_value=httpx.Response(200, json=bodies["electric"])
     )
-    router.get(url__regex=r".*/v1/global/remote/climate-status.*").mock(
+    router.get(url__regex=r".*/v1/vehicle/climate-status.*").mock(
         return_value=httpx.Response(200, json=bodies["climate_status"])
     )
-    router.get(url__regex=r".*/v1/global/remote/climate-settings.*").mock(
+    router.get(url__regex=r".*/v1/vehicle/climate-settings.*").mock(
         return_value=httpx.Response(200, json=bodies["climate_settings"])
     )
     router.get(url__regex=r".*/v1/global/remote/status.*").mock(

--- a/tests/unit_tests/test_climate_settings_endpoints.py
+++ b/tests/unit_tests/test_climate_settings_endpoints.py
@@ -1,0 +1,66 @@
+"""Unit tests pinning the climate-settings read/write endpoint split.
+
+The 2026-07 migration moved the climate-settings *read* to the plain-Bearer
+``/v1/vehicle/climate-settings`` route while the *write* stays on the retired
+``/v1/global/remote/climate-settings`` route (already SigV4-fenced; removed with the
+actuation migration). These tests lock the split so a future edit cannot silently
+repoint the write at the read route (or vice-versa).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pytoyoda.api import Api
+from pytoyoda.const import (
+    VEHICLE_CLIMATE_SETTINGS_ENDPOINT,
+    VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT,
+)
+from pytoyoda.models.endpoints.climate import ClimateSettingsRequestModel
+
+VIN = "Random0815"
+
+
+def test_read_and_write_consts_differ() -> None:
+    """The read (migrated) and write (legacy) settings routes must be distinct."""
+    assert VEHICLE_CLIMATE_SETTINGS_ENDPOINT == "/v1/vehicle/climate-settings"
+    assert (
+        VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT
+        == "/v1/global/remote/climate-settings"
+    )
+    assert VEHICLE_CLIMATE_SETTINGS_ENDPOINT != VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT
+
+
+@pytest.mark.asyncio
+async def test_get_climate_settings_hits_read_endpoint() -> None:
+    """get_climate_settings must GET the migrated read route."""
+    controller = AsyncMock()
+    controller.request_json.return_value = {"status": {"messages": []}, "payload": None}
+    api = Api(controller)
+
+    await api.get_climate_settings(VIN)
+
+    kwargs = controller.request_json.call_args.kwargs
+    assert kwargs["method"] == "GET"
+    assert kwargs["endpoint"] == VEHICLE_CLIMATE_SETTINGS_ENDPOINT
+    assert kwargs["vin"] == VIN
+
+
+@pytest.mark.asyncio
+async def test_update_climate_settings_hits_write_endpoint() -> None:
+    """update_climate_settings must PUT the legacy write route, NOT the read route."""
+    controller = AsyncMock()
+    controller.request_json.return_value = {"status": {"messages": []}}
+    api = Api(controller)
+
+    await api.update_climate_settings(
+        VIN, ClimateSettingsRequestModel(temperature=21.0)
+    )
+
+    kwargs = controller.request_json.call_args.kwargs
+    assert kwargs["method"] == "PUT"
+    assert kwargs["endpoint"] == VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT
+    assert kwargs["endpoint"] != VEHICLE_CLIMATE_SETTINGS_ENDPOINT
+    assert kwargs["vin"] == VIN

--- a/tests/unit_tests/test_models/test_climate.py
+++ b/tests/unit_tests/test_models/test_climate.py
@@ -117,6 +117,24 @@ class TestClimateStatus:
         body = {"status": {"messages": []}, "payload": payload}
         assert _status(body).is_on is expected
 
+    def test_heating_toggle_unknown_is_none(self) -> None:
+        """A heating value that is neither on/off maps to None, not False."""
+        body = {
+            "status": {"messages": []},
+            "payload": {
+                "status": "running",
+                "heatingOptions": {
+                    "frontDefroster": "on",
+                    "rearDefogger": "off",
+                    "steeringHeater": "unknown",
+                },
+            },
+        }
+        heating = _status(body).heating_options
+        assert heating.front_defroster is True
+        assert heating.rear_defogger is False
+        assert heating.steering_heater is None
+
     def test_null_payload_degrades(self) -> None:
         """A None/absent payload (e.g. 403/500) must not raise."""
         assert _status({"status": {"messages": []}, "payload": None}).status is None

--- a/tests/unit_tests/test_models/test_climate.py
+++ b/tests/unit_tests/test_models/test_climate.py
@@ -1,0 +1,172 @@
+"""Test climate status/settings models (/v1/vehicle/climate-*)."""
+
+from datetime import timedelta
+
+import pytest
+
+from pytoyoda.models.climate import ClimateSettings, ClimateStatus
+from pytoyoda.models.endpoints.climate import (
+    ClimateSettingsResponseModel,
+    ClimateStatusResponseModel,
+)
+
+# --- Fixtures: real off-state capture + synthesized on-state (decompiled shape) ---
+
+STATUS_OFF = {"status": {"messages": []}, "payload": {"status": "stopped"}}
+
+STATUS_ON = {
+    "status": {"messages": []},
+    "payload": {
+        "status": "running",
+        "startedAt": "2026-07-01T07:30:00Z",
+        "updatedAt": "2026-07-01T07:36:00Z",
+        "duration": 20,
+        "currentTemperature": {"value": 21.5, "unit": "C"},
+        "targetTemperature": {"value": 22.0, "unit": "C"},
+        "heatingOptions": {
+            "frontDefroster": "on",
+            "rearDefogger": "off",
+            "steeringHeater": "on",
+        },
+        "seatOptions": {
+            "driverSeat": "high",
+            "passengerSeat": "off",
+            "rearDriverSeat": "low",
+            "rearPassengerSeat": "medium",
+        },
+    },
+}
+
+SETTINGS = {
+    "status": {"messages": []},
+    "payload": {
+        "duration": 20,
+        "temperature": {"value": 18.0, "unit": "C"},
+        "heatingOptions": {
+            "frontDefroster": "off",
+            "rearDefogger": "off",
+            "steeringHeater": "off",
+        },
+        "seatOptions": {
+            "driverSeat": "off",
+            "passengerSeat": "off",
+            "rearDriverSeat": "off",
+            "rearPassengerSeat": "off",
+        },
+    },
+}
+
+
+def _status(body: dict) -> ClimateStatus:
+    return ClimateStatus(ClimateStatusResponseModel(**body))
+
+
+def _settings(body: dict) -> ClimateSettings:
+    return ClimateSettings(ClimateSettingsResponseModel(**body))
+
+
+class TestClimateStatus:
+    """ClimateStatus wrapper."""
+
+    def test_off_state_minimal_payload(self) -> None:
+        """Off-state collapses to just ``status``; everything else is None."""
+        st = _status(STATUS_OFF)
+        assert st.status == "stopped"
+        assert st.is_on is False
+        assert st.started_at is None
+        assert st.updated_at is None
+        assert st.duration is None
+        assert st.current_temperature is None
+        assert st.target_temperature is None
+        assert st.heating_options is None
+        assert st.seat_options is None
+
+    def test_on_state_full_payload(self) -> None:
+        """On-state exposes the full rich shape without raising."""
+        st = _status(STATUS_ON)
+        assert st.is_on is True
+        assert st.started_at is not None
+        assert st.updated_at is not None
+        assert st.duration == timedelta(minutes=20)
+        assert st.current_temperature.value == 21.5
+        assert st.current_temperature.unit == "C"
+        assert st.target_temperature.value == 22.0
+        assert st.heating_options.front_defroster is True
+        assert st.heating_options.rear_defogger is False
+        assert st.heating_options.steering_heater is True
+        assert st.seat_options.driver_seat == "high"
+        assert st.seat_options.passenger_seat == "off"
+        assert st.seat_options.rear_driver_seat == "low"
+        assert st.seat_options.rear_passenger_seat == "medium"
+
+    @pytest.mark.parametrize(
+        ("state", "expected"),
+        [
+            ("stopped", False),
+            ("stopping", False),  # transitional-off
+            ("starting", True),  # transitional-on
+            ("running", True),
+            ("RUNNING", True),  # case-insensitive
+            ("weird", None),  # unknown enum -> None, never guessed
+            (None, None),
+        ],
+    )
+    def test_is_on_enum_mapping(self, state: str | None, expected: bool | None) -> None:
+        """is_on maps the closed enum by intent; unknown/None -> None."""
+        payload = {"status": state} if state is not None else {}
+        body = {"status": {"messages": []}, "payload": payload}
+        assert _status(body).is_on is expected
+
+    def test_null_payload_degrades(self) -> None:
+        """A None/absent payload (e.g. 403/500) must not raise."""
+        assert _status({"status": {"messages": []}, "payload": None}).status is None
+        assert ClimateStatus(None).status is None
+        assert ClimateStatus(None).is_on is None
+
+    def test_duration_is_minutes(self) -> None:
+        """Duration is interpreted as minutes, not seconds."""
+        body = {"status": {"messages": []}, "payload": {"status": "running", "duration": 15}}
+        assert _status(body).duration == timedelta(minutes=15)
+
+    def test_serialization_includes_computed_fields(self) -> None:
+        """All computed fields serialize (the #268 @computed_field lesson)."""
+        dumped = _status(STATUS_ON).model_dump()
+        for key in (
+            "status",
+            "is_on",
+            "started_at",
+            "updated_at",
+            "duration",
+            "current_temperature",
+            "target_temperature",
+            "heating_options",
+            "seat_options",
+        ):
+            assert key in dumped
+
+
+class TestClimateSettings:
+    """ClimateSettings wrapper."""
+
+    def test_new_shape(self) -> None:
+        """Temperature/duration/heating/seat come through the new payload."""
+        se = _settings(SETTINGS)
+        assert se.temperature.value == 18.0
+        assert se.temperature.unit == "C"
+        assert se.duration == timedelta(minutes=20)
+        assert se.heating_options.front_defroster is False
+        assert se.seat_options.driver_seat == "off"
+
+    def test_deprecated_accessors_are_inert(self) -> None:
+        """Back-compat accessors return None/[] (no data in the new payload)."""
+        se = _settings(SETTINGS)
+        assert se.settings_on is None
+        assert se.min_temp is None
+        assert se.max_temp is None
+        assert se.temp_interval is None
+        assert se.operations == []
+
+    def test_null_payload_degrades(self) -> None:
+        """A None/absent payload must not raise."""
+        assert _settings({"status": {"messages": []}, "payload": None}).temperature is None
+        assert ClimateSettings(None).temperature is None


### PR DESCRIPTION
## What

Migrate the **climate reads** (`climate-status` + `climate-settings`) from the retired `/v1/global/remote/climate-*` routes to `/v1/vehicle/climate-*`, and reshape the models to the new payloads. Also repoint the climate refresh/wake route. **Read-only** — climate *control* (actuation) is a separate follow-up.

Sibling of #268 (which migrates `status`); same root cause and pattern. Part of #267.

## Why

Since ~26 Jun 2026 the `/v1/global/remote/climate-*` reads return `403 APIGW-403` (`IncompleteSignatureException`) — Toyota moved those routes behind AWS SigV4/IAM. The current MyToyota EU app (2.23.1) reads climate from `/v1/vehicle/climate-*` on the same host with the same plain `Bearer` + `x-api-key`. Endpoint migration, not a signing problem (full evidence in #268).

- Live probe (same `Bearer` JWT) against a Corolla TS: `/v1/global/remote/climate-settings` → 403, `/v1/vehicle/climate-settings` → 200.

## Changes

- **const:** `climate-status`/`climate-settings` **reads** → `/v1/vehicle/*`; `refresh-climate-status` → `/v1/remote/refresh-climate-status`. The settings **write** keeps its own const on the legacy route (see Review focus 2). `climate-control` left unchanged (actuation follow-up).
- **models/endpoints/climate:** reshape `ClimateStatusModel`/`ClimateSettingsModel` to the new directly-typed payloads; new `HeatingOptionsModel` (front defroster / rear defogger / steering heater, `off`/`on`) and `SeatOptionsModel` (4 seats, multi-level `off`/`low`/`medium`/`high`). **All fields optional** (see review focus).
- **models/climate wrappers:** `ClimateStatus` exposes `status`, `is_on`, `started_at`/`updated_at`, `duration`, current/target temperature, `heating_options`, `seat_options`. `ClimateSettings` gains `duration`/`heating_options`/`seat_options`; old `settings_on`/`min_temp`/`max_temp`/`temp_interval`/`operations` kept as **deprecated `None`/`[]`** accessors (back-compat, no consumer breaks).
- **tidy (same new code):** the `off`/`on` and status-enum mappings share one `_tristate(value, true_values, false_values)` helper; redundant `if self._data` guards removed from the `HeatingOptions`/`SeatOptions` accessors (the wrappers are only built with a non-`None` model).
- **tests:** new `test_models/test_climate.py` (off / on / transitional / unknown / null-degrade) and `test_climate_settings_endpoints.py` (read→GET `/v1/vehicle`, write→PUT legacy route); harness routes + bodies repointed.

## ⚠️ Breaking changes (existing `ClimateStatus`/`ClimateSettings` accessors)

The reads reshaped, so a few accessors changed. Downstream should migrate:

- `ClimateStatus.status` — now the **raw backend enum string** (`stopped`/`starting`/`stopping`/`running`), no longer a `bool`. Use **`is_on`** for the boolean.
- Removed from `ClimateStatus`: `.type`, `.start_time` (→ `started_at`), `.options` (→ `heating_options` / `seat_options`).
- `ClimateSettings`: `settings_on`/`min_temp`/`max_temp`/`temp_interval`/`operations` are retained but **inert** (`None`/`[]`) — the new payload doesn't carry them. Use `temperature` / `duration` / `heating_options` / `seat_options`.

## 🔎 Review focus (the two behavioral bits)

1. **`ClimateStatus` now unwraps `response.payload`.** Previously it read `.status`/`.type` off the response *envelope* (a `StatusModel`), so those accessors never returned real climate data — the long-standing "`vehicle.climate_status` doesn't work". This PR fixes that; `status` is the backend enum string and `is_on` maps it by intent (`stopped`/`stopping`→`False`, `starting`/`running`→`True`, unknown/missing→`None`).
2. **Read/write split — this PR moves only the read.** The old `ClimateSettingsModel` and the single `VEHICLE_CLIMATE_SETTINGS_ENDPOINT` const backed **both** the GET read and the PUT write. To keep this PR strictly read-scoped, both are split: the write body is renamed **`ClimateSettingsRequestModel`**, and `update_climate_settings` gets its own **`VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT`** const left on the (already-fenced, non-functional) legacy route. So the read migrates here; the write route is untouched and is removed with the actuation follow-up. A unit test pins that read→`/v1/vehicle` and write→legacy so the two can't silently re-merge.

## Scope

| function | pytoyoda now | new home | status |
|---|---|---|---|
| climate reads (`status`/`settings`) | `/v1/global/remote/climate-*` (403) | `/v1/vehicle/climate-*` | ✅ this PR, verified 200 |
| climate refresh/wake | `/v1/global/remote/refresh-climate-status` | `/v1/remote/refresh-climate-status` | ✅ this PR, benign wake verified |
| climate settings **write** | `PUT /v1/global/remote/climate-settings` | (own const; removed in actuation PR) | held for follow-up |
| climate control (actuation) | `/v1/global/remote/climate-control` | `/v2/remote/climate-control` (new body) | follow-up |

## Verification

- New unit tests + full suite green (133 passed); `ruff check`/`format` clean on the package.
- **Live** against a Corolla TS: `vehicle.update(only=["climate_status","climate_settings"])` populates with no `APIGW-403` (settings `temperature` = 18.0 C, status `stopped`); migrated `refresh_climate_status` wake returns success.
- **On-state models:** the live car was *off* during probing (off-state payload is just `{"status":"stopped"}`), so the richer running-state fields were sized from the **decompiled app contract** (`VehicleClimate*Payload` + `RemoteClimateStatus$Status` enum) and covered by a synthesized on-state test. Because every field is optional, an unexpected shape degrades to `None` rather than raising.

> The failing `pre-commit.ci` check is the pre-existing `TC003` on `controller.py` (`import ssl`), unrelated to this PR — already red on `main` since pre-commit.ci runs `--all-files`.

---

### The #267 migration, at a glance

Toyota fenced the whole `/v1/global/remote/*` family behind AWS SigV4 (→ `APIGW-403`); this series moves each surface onto the plain-Bearer routes the live MyToyota EU app (2.23.1) uses. **Four PRs, two independent chains:**

| PR | surface | route move | stacked on | breaking? |
|----|---------|-----------|-----------|-----------|
| #268 | status read | `…/remote/status` → `/v1/vehicle/status` | — | no |
| #270 | status wake | `POST …/remote/refresh-status` → `POST /v1/remote/status` | #268 | no |
| #269 | climate reads | `…/remote/climate-*` → `/v1/vehicle/climate-*` | — | yes ¹ |
| #271 | climate actuation | settings-PUT + control-POST → `POST /v2/remote/climate-control` | #269 | yes ² |

Suggested merge order: **#268 → #270** and **#269 → #271**; the two chains are independent and don't touch each other's files. Remote commands (lock/unlock/…) on `/v1/global/remote/command` are **not affected** — still plain Bearer, verified working.

¹ #269 reshapes the `ClimateStatus`/`ClimateSettings` accessors. ² #271 removes `update_climate_settings`. Both are detailed in their own PRs.
