### PR TITLE
fix(status): migrate status wake to /v1/remote/status (part of #267)

### DIFF
--- a/pytoyoda/api.py
+++ b/pytoyoda/api.py
@@ -250,14 +250,15 @@ class Api:
     async def refresh_vehicle_status(self, vin: str) -> RefreshStatusResponseModel:
         """Wake the vehicle and request a fresh /status cache populate.
 
-        Calls Toyota's POST /v1/global/remote/refresh-status. The car's
-        cellular modem is woken; on success the gateway populates the
-        cache that GET /status reads. Toyota's mobile app issues this
-        before reading status to avoid 429+APIGW-403 from a cold cache.
+        Calls Toyota's POST /v1/remote/status. The car's cellular modem is
+        woken; on success the gateway populates the cache that GET
+        /v1/vehicle/status reads. Toyota's mobile app issues this before
+        reading status to warm a cold cache.
 
-        The body shape (deviceId/deviceType/guid/vin) is required;
-        without it the gateway returns 500 (this was the root cause of
-        the abandoned PR #302/#77 force_update path).
+        The old /v1/global/remote/refresh-status route required a
+        deviceId/deviceType/guid/vin body and is now SigV4-fenced
+        (APIGW-403). The new /v1/remote/* route takes the vin as a header
+        only (no body), matching the migrated climate wake.
 
         Args:
             vin: Vehicle Identification Number
@@ -269,18 +270,11 @@ class Api:
                 does not support the endpoint.
 
         """
-        body = {
-            "deviceId": "pytoyoda",
-            "deviceType": "Android",
-            "guid": self.controller._uuid,  # noqa: SLF001
-            "vin": vin,
-        }
         return await self._request_and_parse(
             RefreshStatusResponseModel,
             "POST",
             VEHICLE_GLOBAL_REMOTE_REFRESH_STATUS_ENDPOINT,
             vin=vin,
-            body=body,
         )
 
     async def get_telemetry(self, vin: str) -> TelemetryResponseModel:

--- a/pytoyoda/const.py
+++ b/pytoyoda/const.py
@@ -21,7 +21,12 @@ VEHICLE_HEALTH_STATUS_ENDPOINT = "/v1/vehiclehealth/status"
 # AWS SigV4 -> returns APIGW-403). The live app reads status from /v1/vehicle/status
 # on the plain-Bearer authorizer. Const name kept to avoid churn in api.py.
 VEHICLE_GLOBAL_REMOTE_STATUS_ENDPOINT = "/v1/vehicle/status"
-VEHICLE_GLOBAL_REMOTE_REFRESH_STATUS_ENDPOINT = "/v1/global/remote/refresh-status"
+# Migrated 2026-07: the status wake moved off the retired /v1/global/remote/*
+# family (now SigV4-fenced -> APIGW-403) to the plain-Bearer /v1/remote/* refresh
+# namespace, mirroring the already-migrated climate wake. The new route takes no
+# body (vin header only) and returns payload.returnCode "000000" on accept.
+# Const name kept to avoid churn in api.py.
+VEHICLE_GLOBAL_REMOTE_REFRESH_STATUS_ENDPOINT = "/v1/remote/status"
 VEHICLE_GLOBAL_REMOTE_ELECTRIC_STATUS_ENDPOINT = "/v1/global/remote/electric/status"
 VEHICLE_GLOBAL_REMOTE_ELECTRIC_REALTIME_STATUS_ENDPOINT = (
     "/v1/global/remote/electric/realtime-status"

--- a/pytoyoda/models/endpoints/refresh_status.py
+++ b/pytoyoda/models/endpoints/refresh_status.py
@@ -1,12 +1,13 @@
-"""Toyota Connected Services API - POST /v1/global/remote/refresh-status.
+"""Toyota Connected Services API - POST /v1/remote/status.
 
-Sent before reading /v1/global/remote/status to wake the vehicle's cellular
-modem so the gateway populates the cache that GET reads. The empirical
-contract was reverse-engineered from the Toyota Android app and confirmed
-on 2026-04-24:
+Sent before reading /v1/vehicle/status to wake the vehicle's cellular modem so
+the gateway populates the cache that GET reads. The old
+/v1/global/remote/refresh-status route required a deviceId/deviceType/guid/vin
+body and is now SigV4-fenced (APIGW-403); the migrated /v1/remote/* route takes
+the vin as a header only (no body). Contract confirmed against a live car
+2026-07-01:
 
-    POST /v1/global/remote/refresh-status
-    body: {"deviceId": str, "deviceType": "Android", "guid": str, "vin": str}
+    POST /v1/remote/status   (vin header, no body)
     -> 200 OK
        payload.returnCode == "000000"  -> wake accepted
        payload.returnCode != "000000"  -> vehicle does not support endpoint
@@ -23,12 +24,13 @@ from pytoyoda.utils.models import CustomEndpointBaseModel
 
 
 class RefreshStatusPayloadModel(CustomEndpointBaseModel):
-    """Payload of the POST /v1/global/remote/refresh-status response."""
+    """Payload of the POST /v1/remote/status response."""
 
+    app_request_no: str | None = Field(alias="appRequestNo", default=None)
     return_code: str | None = Field(alias="returnCode", default=None)
 
 
 class RefreshStatusResponseModel(StatusModel):
-    """Full response wrapper for POST /v1/global/remote/refresh-status."""
+    """Full response wrapper for POST /v1/remote/status."""
 
     payload: RefreshStatusPayloadModel | None = None

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -392,7 +392,7 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
     async def refresh_status(self) -> RefreshStatusResponseModel:
         """Wake the vehicle and request a fresh /status cache populate.
 
-        Issues POST /v1/global/remote/refresh-status. Use sparingly:
+        Issues POST /v1/remote/status. Use sparingly:
         each call uses cellular airtime and a small amount of 12V battery.
         Returns when the gateway has accepted the wake request, NOT when
         the cache has actually been populated; the caller should poll

--- a/tests/harness/mock_server.py
+++ b/tests/harness/mock_server.py
@@ -133,10 +133,11 @@ _BODIES_CACHE: dict[str, Any] | None = None
 # ---------------------------------------------------------------------------
 # Per-VIN cache-expiry simulator (for smart-strategy TDD, 2026-04-25+).
 #
-# Models the Toyota two-stage protocol we discovered on 2026-04-24:
-#   - GET  /v1/global/remote/status         reads the cache (429+APIGW-403 if cold/stale)
-#   - POST /v1/global/remote/refresh-status wakes the car (200/returnCode 000000),
-#                                            cache populates if the car responds
+# Models the Toyota two-stage protocol we discovered on 2026-04-24 (endpoints
+# migrated 2026-07 off the retired /v1/global/remote/* family):
+#   - GET  /v1/vehicle/status  reads the cache (429+APIGW-403 if cold/stale)
+#   - POST /v1/remote/status   wakes the car (200/returnCode 000000),
+#                              cache populates if the car responds
 #
 # Simulator invariants (per VIN):
 #   - cache_populated_at: when the cache was last refreshed by a successful POST
@@ -240,24 +241,6 @@ class _Registry:
 SIM = _Registry()
 
 
-def _vin_from_path_or_body(path: str, body_bytes: bytes | None) -> str:
-    """Resolve the VIN this request targets.
-
-    /status: VIN comes from the X-VIN header (handled separately - we cannot get
-    headers here). Fallback to a default 'DEFAULT' VIN if nothing else.
-
-    /refresh-status: VIN is in the JSON body.
-    """
-    if body_bytes:
-        try:
-            data = json.loads(body_bytes)
-            if isinstance(data, dict) and "vin" in data:
-                return str(data["vin"])
-        except (json.JSONDecodeError, ValueError):
-            pass
-    return "DEFAULT"
-
-
 _APIGW_403_BODY = json.dumps({"code": "APIGW-403", "message": "Unauthorized"}).encode()
 
 
@@ -305,9 +288,10 @@ def _route(
         return 200, {"Content-Type": "application/json"}, json.dumps(b["tokens"]).encode()
 
     # --- Smart-strategy endpoints (simulator-backed) ---
-    # POST /v1/global/remote/refresh-status (must precede /status check below)
-    if method == "POST" and "/v1/global/remote/refresh-status" in base_path:
-        vin = _vin_from_path_or_body(path, body_bytes)
+    # POST /v1/remote/status wake (migrated from /v1/global/remote/refresh-status,
+    # now SigV4-fenced). VIN travels in the header now, not a JSON body.
+    if method == "POST" and "/v1/remote/status" in base_path:
+        vin = headers.get("vin") or headers.get("VIN") or "DEFAULT"
         sim = SIM.get(vin)
         now = time.monotonic()
         sim.last_post_at = now

--- a/tests/harness/test_cache_expiry_contract.py
+++ b/tests/harness/test_cache_expiry_contract.py
@@ -1,8 +1,8 @@
 """Contract tests for the cache-expiry simulator added to mock_server.py.
 
 These run in seconds against the in-process HTTPS harness, exercising the
-two-stage protocol we discovered on 2026-04-24 (POST /refresh-status to wake
-the car, GET /status to read the cache). This is the foundation of the
+two-stage protocol we discovered on 2026-04-24 (POST /v1/remote/status to wake
+the car, GET /v1/vehicle/status to read the cache). This is the foundation of the
 smart-strategy TDD work; pytoyoda's `refresh_vehicle_status()` and ha_toyota's
 decision tree will be tested against the same simulator.
 
@@ -46,10 +46,8 @@ def _get_status(client, vin: str) -> httpx.Response:
 
 
 def _post_refresh(client, vin: str) -> httpx.Response:
-    return client.post(
-        "/v1/global/remote/refresh-status",
-        json={"deviceId": "harness", "deviceType": "Android", "guid": "g", "vin": vin},
-    )
+    # Migrated wake: POST /v1/remote/status, vin in the header, no body.
+    return client.post("/v1/remote/status", headers={"vin": vin})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_refresh_vehicle_status.py
+++ b/tests/unit_tests/test_refresh_vehicle_status.py
@@ -20,10 +20,12 @@ GUID = "123e4567-e89b-12d3-a456-426614174000"
 
 
 @pytest.mark.asyncio
-async def test_refresh_vehicle_status_sends_correct_body_and_endpoint():
-    """The POST must hit /refresh-status with the four-field body shape that
-    the gateway requires (deviceId/deviceType/guid/vin). Without these fields
-    the gateway returns 500 (the trap PR #302 fell into)."""
+async def test_refresh_vehicle_status_sends_correct_endpoint_no_body():
+    """The POST must hit the migrated /v1/remote/status wake route with the vin
+    as a header only. The old /v1/global/remote/refresh-status route required a
+    deviceId/deviceType/guid/vin body and is now SigV4-fenced (APIGW-403); the
+    new route takes no body (confirmed against a live car 2026-07-01).
+    """
     controller = AsyncMock()
     controller._uuid = GUID
     controller.request_json.return_value = {"status": {"messages": []}, "payload": {}}
@@ -37,19 +39,14 @@ async def test_refresh_vehicle_status_sends_correct_body_and_endpoint():
     assert kwargs["method"] == "POST"
     assert kwargs["endpoint"] == VEHICLE_GLOBAL_REMOTE_REFRESH_STATUS_ENDPOINT
     assert kwargs["vin"] == VIN
-    body = kwargs["body"]
-    assert body == {
-        "deviceId": "pytoyoda",
-        "deviceType": "Android",
-        "guid": GUID,
-        "vin": VIN,
-    }
+    assert "body" not in kwargs
 
 
 @pytest.mark.asyncio
 async def test_refresh_vehicle_status_parses_response_with_return_code():
     """The 'returnCode' field on the JSON payload becomes return_code on the
-    parsed model (snake_case via Pydantic Field alias)."""
+    parsed model (snake_case via Pydantic Field alias).
+    """
     controller = AsyncMock()
     controller._uuid = GUID
     controller.request_json.return_value = {
@@ -68,7 +65,8 @@ async def test_refresh_vehicle_status_parses_response_with_return_code():
 @pytest.mark.asyncio
 async def test_refresh_vehicle_status_handles_layer1_failure_payload():
     """Non-000000 returnCode (vehicle does not support endpoint) parses as
-    a regular response - the caller decides what to do with it."""
+    a regular response - the caller decides what to do with it.
+    """
     controller = AsyncMock()
     controller._uuid = GUID
     controller.request_json.return_value = {


### PR DESCRIPTION
Part of #267. Third and final read-surface migration in the series (after #268 status, #269 climate).

## What
Toyota retired the `POST /v1/global/remote/refresh-status` status-wake route behind an AWS SigV4/IAM authorizer — plain-Bearer clients now get `403 APIGW-403 / IncompleteSignatureException`. The live MyToyota EU 2.23.1 app moved the status wake to the plain-Bearer `POST /v1/remote/status` route, mirroring the already-migrated climate wake (`/v1/remote/refresh-climate-status`).

This repoints `VEHICLE_GLOBAL_REMOTE_REFRESH_STATUS_ENDPOINT` → `/v1/remote/status` and drops the old `{deviceId, deviceType, guid, vin}` body — the new route takes the `vin` as a header only. `appRequestNo` is added to the response payload model; `returnCode "000000"` still marks accept.

## Verification (live, against a real Corolla TS, 2026-07-01)
```
POST /v1/remote/status          (no body)  -> 200  payload.returnCode "000000"   ✅
POST /v1/global/remote/refresh-status (old) -> 403  IncompleteSignatureException  (retired)
```
Full 200 body:
```json
{"status":{"serviceIdentifier":"dcm19-remote-service","messages":[{"responseCode":"CTP-GENERIC-20001","description":"Success"}]},
 "payload":{"appRequestNo":"…","returnCode":"000000"}}
```
Deployed to a live HA install and confirmed the on-demand wake now advances the car's reported timestamp (a manual refresh moved `status_last_reported_by_car` forward within ~12s), with no 403 and no throttle-state flapping.

## Notes for review
- **Stacked on #268** — this branch is built on `fix/migrate-status-endpoints`, so the diff currently also shows #268's commits (`status.py`/`lock_status.py`). The wake migration itself is a single commit on top (`pytoyoda/const.py`, `api.py`, `models/vehicle.py`, `models/endpoints/refresh_status.py`, plus harness/tests). Once #268 merges, those files drop from this diff. The harness coupling is why it's stacked rather than cut from `main`: the mock server's status GET route is #268's `/v1/vehicle/status`.
- Unit suite green (127 passed). Harness cache-expiry contract tests updated to the new route/header shape (they run behind a local TLS cert fixture).

---

### The #267 migration, at a glance

Toyota fenced the whole `/v1/global/remote/*` family behind AWS SigV4 (→ `APIGW-403`); this series moves each surface onto the plain-Bearer routes the live MyToyota EU app (2.23.1) uses. **Four PRs, two independent chains:**

| PR | surface | route move | stacked on | breaking? |
|----|---------|-----------|-----------|-----------|
| #268 | status read | `…/remote/status` → `/v1/vehicle/status` | — | no |
| #270 | status wake | `POST …/remote/refresh-status` → `POST /v1/remote/status` | #268 | no |
| #269 | climate reads | `…/remote/climate-*` → `/v1/vehicle/climate-*` | — | yes ¹ |
| #271 | climate actuation | settings-PUT + control-POST → `POST /v2/remote/climate-control` | #269 | yes ² |

Suggested merge order: **#268 → #270** and **#269 → #271**; the two chains are independent and don't touch each other's files. Remote commands (lock/unlock/…) on `/v1/global/remote/command` are **not affected** — still plain Bearer, verified working.

¹ #269 reshapes the `ClimateStatus`/`ClimateSettings` accessors. ² #271 removes `update_climate_settings`. Both are detailed in their own PRs.
