### PR TITLE
feat(climate): actuate via POST /v2/remote/climate-control (part of #267)

### DIFF
--- a/pytoyoda/api.py
+++ b/pytoyoda/api.py
@@ -10,7 +10,6 @@ from pytoyoda.const import (
     VEHICLE_ASSOCIATION_ENDPOINT,
     VEHICLE_CLIMATE_CONTROL_ENDPOINT,
     VEHICLE_CLIMATE_SETTINGS_ENDPOINT,
-    VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT,
     VEHICLE_CLIMATE_STATUS_ENDPOINT,
     VEHICLE_CLIMATE_STATUS_REFRESH_ENDPOINT,
     VEHICLE_COMMAND_ENDPOINT,
@@ -29,10 +28,10 @@ from pytoyoda.const import (
 )
 from pytoyoda.controller import Controller
 from pytoyoda.models.endpoints.climate import (
-    ClimateControlModel,
-    ClimateSettingsRequestModel,
     ClimateSettingsResponseModel,
     ClimateStatusResponseModel,
+    RemoteClimateControlResponseModel,
+    V2RemoteClimateControlRequestModel,
 )
 from pytoyoda.models.endpoints.command import CommandType, RemoteCommandModel
 from pytoyoda.models.endpoints.common import StatusModel
@@ -391,46 +390,31 @@ class Api:
             vin=vin,
         )
 
-    async def update_climate_settings(
-        self, vin: str, settings: ClimateSettingsRequestModel
-    ) -> StatusModel:
-        """Update the climate control settings for a vehicle.
-
-        Args:
-            vin: Vehicle Identification Number
-            settings: New climate control settings
-
-        Returns:
-            Model containing status of the update request
-
-        """
-        return await self._request_and_parse(
-            StatusModel,
-            "PUT",
-            VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT,
-            vin=vin,
-            body=settings.model_dump(exclude_unset=True, by_alias=True),
-        )
-
     async def send_climate_control_command(
-        self, vin: str, command: ClimateControlModel
-    ) -> StatusModel:
-        """Send a control command to the climate system.
+        self, vin: str, request: V2RemoteClimateControlRequestModel
+    ) -> RemoteClimateControlResponseModel:
+        """Start or stop remote climate via POST /v2/remote/climate-control.
+
+        The unified V2 endpoint replaces the old settings-PUT + control-POST: a
+        ``start`` request carries the full desired settings (temperature + heating/
+        seat options + ``save_settings``); a ``stop`` is just ``command="stop"``.
+        Command success is ``response.payload.return_code == "000000"``; confirmation
+        of the actual on/off state is via the climate-status read.
 
         Args:
             vin: Vehicle Identification Number
-            command: Climate control command to send
+            request: The V2 climate-control request body.
 
         Returns:
-            Model containing status of the command request
+            Model containing the command acknowledgement (request id + return code).
 
         """
         return await self._request_and_parse(
-            StatusModel,
+            RemoteClimateControlResponseModel,
             "POST",
             VEHICLE_CLIMATE_CONTROL_ENDPOINT,
             vin=vin,
-            body=command.model_dump(exclude_unset=True, by_alias=True),
+            body=request.model_dump(exclude_none=True, by_alias=True),
         )
 
     # Trip Data

--- a/pytoyoda/const.py
+++ b/pytoyoda/const.py
@@ -34,15 +34,11 @@ VEHICLE_SERVICE_HISTORY_ENDPONT = "/v1/servicehistory/vehicle/summary"
 # Migrated 2026-07: Toyota retired the /v1/global/remote/climate-* read routes
 # (now behind AWS SigV4 -> APIGW-403). The live MyToyota app reads climate from
 # the plain-Bearer /v1/vehicle/climate-* namespace and wakes via /v1/remote/*.
-# Actuation (climate-control) moves to POST /v2/remote/climate-control with a new
-# body (V2RemoteClimateControlRequest) and is migrated separately.
-VEHICLE_CLIMATE_CONTROL_ENDPOINT = "/v1/global/remote/climate-control"
+# Actuation (climate-control) moved to POST /v2/remote/climate-control with a new
+# unified body (V2RemoteClimateControlRequest: command start/stop + temperature +
+# heating/seat options + saveSettings) replacing the old settings-PUT + control-POST.
+VEHICLE_CLIMATE_CONTROL_ENDPOINT = "/v2/remote/climate-control"
 VEHICLE_CLIMATE_SETTINGS_ENDPOINT = "/v1/vehicle/climate-settings"
-# The settings *write* (update_climate_settings) still targets the retired
-# /v1/global/remote route. That route is already SigV4-fenced, so the write is
-# non-functional regardless; it is removed with the actuation migration. Split from
-# the read const above so this change moves only the read.
-VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT = "/v1/global/remote/climate-settings"
 VEHICLE_CLIMATE_STATUS_ENDPOINT = "/v1/vehicle/climate-status"
 VEHICLE_CLIMATE_STATUS_REFRESH_ENDPOINT = "/v1/remote/refresh-climate-status"
 VEHICLE_COMMAND_ENDPOINT = "/v1/global/remote/command"

--- a/pytoyoda/models/endpoints/climate.py
+++ b/pytoyoda/models/endpoints/climate.py
@@ -18,7 +18,7 @@ read models below no longer share their shape — actuation is moving to
 
 from datetime import datetime
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from pytoyoda.models.endpoints.common import StatusModel, UnitValueModel
 from pytoyoda.utils.models import CustomEndpointBaseModel
@@ -33,6 +33,10 @@ class HeatingOptionsModel(CustomEndpointBaseModel):
         steering_heater: Steering-wheel heater state.
 
     """
+
+    # Also constructed in Python (the climate-control write body), so accept both the
+    # snake_case field names and the camelCase wire aliases.
+    model_config = ConfigDict(populate_by_name=True)
 
     front_defroster: str | None = Field(alias="frontDefroster", default=None)
     rear_defogger: str | None = Field(alias="rearDefogger", default=None)
@@ -49,6 +53,8 @@ class SeatOptionsModel(CustomEndpointBaseModel):
         rear_passenger_seat: Rear passenger-side seat heater level.
 
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     driver_seat: str | None = Field(alias="driverSeat", default=None)
     passenger_seat: str | None = Field(alias="passengerSeat", default=None)
@@ -109,89 +115,53 @@ class ClimateSettingsModel(CustomEndpointBaseModel):
     seat_options: SeatOptionsModel | None = Field(alias="seatOptions", default=None)
 
 
-# --- Legacy write bodies (actuation not yet migrated to /v2/remote/climate-control) ---
+# --- Climate control (actuation) — POST /v2/remote/climate-control ---
 
 
-class ACParameters(CustomEndpointBaseModel):
-    """Legacy AC parameter (write body).
+class V2RemoteClimateControlRequestModel(CustomEndpointBaseModel):
+    """Unified climate-control request body (``POST /v2/remote/climate-control``).
+
+    Replaces the old settings-PUT + control-POST. A ``start`` carries the full desired
+    settings; a ``stop`` is just ``command`` (the rest serialize away via
+    ``exclude_none``). Reuses the shared ``HeatingOptionsModel``/``SeatOptionsModel``
+    read shapes, so the model already supports future writable seat/steering surfaces.
 
     Attributes:
-        available: Whether the AC parameter is available
-        display_name: User-friendly name to display in UI
-        enabled: Whether the AC parameter is enabled
-        icon_url: URL to icon representing the parameter
-        name: Internal identifier for the parameter
+        command: ``"start"`` or ``"stop"`` (RemoteClimateControl backend values).
+        duration: Run duration in minutes; ``None`` = car's saved/default.
+        temperature: Target temperature (value + unit).
+        heating_options: Front defroster / rear defogger / steering heater (on/off).
+        seat_options: Per-seat heater levels.
+        save_settings: Persist these settings as the car's defaults.
 
     """
 
-    available: bool | None = None
-    display_name: str | None = Field(alias="displayName", default=None)
-    enabled: bool = False
-    icon_url: str | None = Field(alias="iconUrl", default=None)
-    name: str
-
-
-class ACOperations(CustomEndpointBaseModel):
-    """Legacy AC operation (write body).
-
-    Attributes:
-        available: Whether the operation is available
-        category_display_name: User-friendly category name
-        category_name: Internal category identifier
-        ac_parameters: List of AC parameters for this operation
-
-    """
-
-    available: bool | None = None
-    category_display_name: str | None = Field(alias="categoryDisplayName", default=None)
-    category_name: str = Field(alias="categoryName")
-    ac_parameters: list[ACParameters] = Field(
-        alias="acParameters", default_factory=list
-    )
-
-
-class ClimateSettingsRequestModel(CustomEndpointBaseModel):
-    """Legacy climate-settings write body (``PUT`` climate-settings).
-
-    Superseded by the unified ``POST /v2/remote/climate-control`` request; kept so the
-    not-yet-migrated actuation path continues to type-check.
-
-    Attributes:
-        ac_operations: List of AC operations to apply
-        settings_on: Whether climate settings are active
-        temperature: Target temperature
-        temperature_unit: Unit of temperature (C or F)
-
-    """
-
-    ac_operations: list[ACOperations] | None = Field(alias="acOperations", default=None)
-    settings_on: bool | None = Field(alias="settingsOn", default=None)
-    temperature: float | None = None
-    temperature_unit: str | None = Field(alias="temperatureUnit", default=None)
-
-
-class RemoteHVACModel(CustomEndpointBaseModel):
-    """Model representing remote HVAC settings.
-
-    Attributes:
-        engine_start_time: Time in minutes for engine to run
-
-    """
-
-    engine_start_time: int = Field(alias="engineStartTime")
-
-
-class ClimateControlModel(CustomEndpointBaseModel):
-    """Legacy climate control command body.
-
-    Attributes:
-        command: Command to execute (e.g., "engine-start", "engine-stop")
-        remote_hvac: Additional HVAC settings if applicable
-
-    """
+    # Built in Python by the consumer; accept snake_case field names too.
+    model_config = ConfigDict(populate_by_name=True)
 
     command: str
-    remote_hvac: RemoteHVACModel | None = Field(alias="remoteHvac", default=None)
+    duration: int | None = None
+    temperature: UnitValueModel | None = None
+    heating_options: HeatingOptionsModel | None = Field(
+        alias="heatingOptions", default=None
+    )
+    seat_options: SeatOptionsModel | None = Field(alias="seatOptions", default=None)
+    save_settings: bool | None = Field(alias="saveSettings", default=None)
+
+
+class RemoteClimateControlPayloadModel(CustomEndpointBaseModel):
+    """Climate-control command acknowledgement payload.
+
+    Attributes:
+        app_request_no: Backend request id for the async command.
+        return_code: Command result; ``"000000"`` = accepted/success. Other codes
+            (e.g. ``118003``/``600000``/``200000``) are precondition failures
+            (car unlocked, door open, key inside, already started).
+
+    """
+
+    app_request_no: str | None = Field(alias="appRequestNo", default=None)
+    return_code: str | None = Field(alias="returnCode", default=None)
 
 
 class ClimateSettingsResponseModel(StatusModel):
@@ -214,3 +184,17 @@ class ClimateStatusResponseModel(StatusModel):
     """
 
     payload: ClimateStatusModel | None = None
+
+
+class RemoteClimateControlResponseModel(StatusModel):
+    """Model representing a climate-control command response.
+
+    The command result lives in ``payload.return_code`` (``"000000"`` = success),
+    a distinct layer from the envelope's ``status.messages[].response_code``.
+
+    Attributes:
+        payload: The command acknowledgement (request id + return code).
+
+    """
+
+    payload: RemoteClimateControlPayloadModel | None = None

--- a/pytoyoda/models/vehicle.py
+++ b/pytoyoda/models/vehicle.py
@@ -20,6 +20,10 @@ from pytoyoda.exceptions import ToyotaApiError
 from pytoyoda.models.climate import ClimateSettings, ClimateStatus
 from pytoyoda.models.dashboard import Dashboard
 from pytoyoda.models.electric_status import ElectricStatus
+from pytoyoda.models.endpoints.climate import (
+    RemoteClimateControlResponseModel,
+    V2RemoteClimateControlRequestModel,
+)
 from pytoyoda.models.endpoints.command import CommandType
 from pytoyoda.models.endpoints.common import StatusModel
 from pytoyoda.models.endpoints.electric import (
@@ -714,6 +718,25 @@ class Vehicle(CustomAPIBaseModel[type[T]]):
 
         """
         return await self._api.refresh_climate_status(self.vin)
+
+    async def set_climate(
+        self, request: V2RemoteClimateControlRequestModel
+    ) -> RemoteClimateControlResponseModel:
+        """Start or stop remote climate control (POST /v2/remote/climate-control).
+
+        A ``start`` request carries the full desired settings (temperature +
+        heating/seat options + ``save_settings``); a ``stop`` is just
+        ``command="stop"``. Acknowledgement is ``response.payload.return_code ==
+        "000000"``; confirm the actual on/off state via the climate-status read.
+
+        Args:
+            request: The V2 climate-control request body.
+
+        Returns:
+            RemoteClimateControlResponseModel: The command acknowledgement.
+
+        """
+        return await self._api.send_climate_control_command(self.vin, request)
 
     async def post_command(self, command: CommandType, beeps: int = 0) -> StatusModel:
         """Send remote command to the vehicle.

--- a/tests/unit_tests/test_climate_settings_endpoints.py
+++ b/tests/unit_tests/test_climate_settings_endpoints.py
@@ -1,10 +1,8 @@
-"""Unit tests pinning the climate-settings read/write endpoint split.
+"""Unit test pinning the migrated climate-settings read endpoint.
 
-The 2026-07 migration moved the climate-settings *read* to the plain-Bearer
-``/v1/vehicle/climate-settings`` route while the *write* stays on the retired
-``/v1/global/remote/climate-settings`` route (already SigV4-fenced; removed with the
-actuation migration). These tests lock the split so a future edit cannot silently
-repoint the write at the read route (or vice-versa).
+The 2026-07 migration moved the climate-settings read to the plain-Bearer
+``/v1/vehicle/climate-settings`` route. (The old settings *write* was removed with
+the actuation migration to ``POST /v2/remote/climate-control``.)
 """
 
 from __future__ import annotations
@@ -14,23 +12,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from pytoyoda.api import Api
-from pytoyoda.const import (
-    VEHICLE_CLIMATE_SETTINGS_ENDPOINT,
-    VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT,
-)
-from pytoyoda.models.endpoints.climate import ClimateSettingsRequestModel
+from pytoyoda.const import VEHICLE_CLIMATE_SETTINGS_ENDPOINT
 
 VIN = "Random0815"
-
-
-def test_read_and_write_consts_differ() -> None:
-    """The read (migrated) and write (legacy) settings routes must be distinct."""
-    assert VEHICLE_CLIMATE_SETTINGS_ENDPOINT == "/v1/vehicle/climate-settings"
-    assert (
-        VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT
-        == "/v1/global/remote/climate-settings"
-    )
-    assert VEHICLE_CLIMATE_SETTINGS_ENDPOINT != VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT
 
 
 @pytest.mark.asyncio
@@ -45,22 +29,5 @@ async def test_get_climate_settings_hits_read_endpoint() -> None:
     kwargs = controller.request_json.call_args.kwargs
     assert kwargs["method"] == "GET"
     assert kwargs["endpoint"] == VEHICLE_CLIMATE_SETTINGS_ENDPOINT
-    assert kwargs["vin"] == VIN
-
-
-@pytest.mark.asyncio
-async def test_update_climate_settings_hits_write_endpoint() -> None:
-    """update_climate_settings must PUT the legacy write route, NOT the read route."""
-    controller = AsyncMock()
-    controller.request_json.return_value = {"status": {"messages": []}}
-    api = Api(controller)
-
-    await api.update_climate_settings(
-        VIN, ClimateSettingsRequestModel(temperature=21.0)
-    )
-
-    kwargs = controller.request_json.call_args.kwargs
-    assert kwargs["method"] == "PUT"
-    assert kwargs["endpoint"] == VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT
-    assert kwargs["endpoint"] != VEHICLE_CLIMATE_SETTINGS_ENDPOINT
+    assert kwargs["endpoint"] == "/v1/vehicle/climate-settings"
     assert kwargs["vin"] == VIN

--- a/tests/unit_tests/test_models/test_climate.py
+++ b/tests/unit_tests/test_models/test_climate.py
@@ -8,7 +8,12 @@ from pytoyoda.models.climate import ClimateSettings, ClimateStatus
 from pytoyoda.models.endpoints.climate import (
     ClimateSettingsResponseModel,
     ClimateStatusResponseModel,
+    HeatingOptionsModel,
+    RemoteClimateControlResponseModel,
+    SeatOptionsModel,
+    V2RemoteClimateControlRequestModel,
 )
+from pytoyoda.models.endpoints.common import UnitValueModel
 
 # --- Fixtures: real off-state capture + synthesized on-state (decompiled shape) ---
 
@@ -188,3 +193,71 @@ class TestClimateSettings:
         """A None/absent payload must not raise."""
         assert _settings({"status": {"messages": []}, "payload": None}).temperature is None
         assert ClimateSettings(None).temperature is None
+
+
+class TestV2ClimateControl:
+    """V2 climate-control request/response models (POST /v2/remote/climate-control)."""
+
+    def test_stop_serializes_to_command_only(self) -> None:
+        """STOP reduces to just {"command": "stop"} under exclude_none."""
+        stop = V2RemoteClimateControlRequestModel(command="stop")
+        assert stop.model_dump(exclude_none=True, by_alias=True) == {"command": "stop"}
+
+    def test_start_full_body_by_alias(self) -> None:
+        """START emits the full camelCase wire body from snake_case construction."""
+        start = V2RemoteClimateControlRequestModel(
+            command="start",
+            temperature=UnitValueModel(unit="C", value=21.0),
+            heating_options=HeatingOptionsModel(
+                front_defroster="on", rear_defogger="off", steering_heater="off"
+            ),
+            seat_options=SeatOptionsModel(
+                driver_seat="off",
+                passenger_seat="off",
+                rear_driver_seat="off",
+                rear_passenger_seat="off",
+            ),
+            save_settings=True,
+        )
+        body = start.model_dump(exclude_none=True, by_alias=True)
+        assert body["command"] == "start"
+        assert body["temperature"] == {"unit": "C", "value": 21.0}
+        assert body["heatingOptions"] == {
+            "frontDefroster": "on",
+            "rearDefogger": "off",
+            "steeringHeater": "off",
+        }
+        assert body["seatOptions"]["driverSeat"] == "off"
+        assert body["saveSettings"] is True
+
+    def test_none_subfield_is_omitted_not_guessed(self) -> None:
+        """An unknown (None) heating value is omitted, never sent as a guessed off."""
+        start = V2RemoteClimateControlRequestModel(
+            command="start",
+            heating_options=HeatingOptionsModel(
+                front_defroster="on", rear_defogger="off", steering_heater=None
+            ),
+        )
+        heating = start.model_dump(exclude_none=True, by_alias=True)["heatingOptions"]
+        assert heating == {"frontDefroster": "on", "rearDefogger": "off"}
+        assert "steeringHeater" not in heating
+
+    def test_response_return_code(self) -> None:
+        """Command success lives in payload.return_code (not the envelope code)."""
+        resp = RemoteClimateControlResponseModel(
+            **{
+                "status": {"messages": [{"responseCode": "ONE-GLOBAL-RS-10000"}]},
+                "payload": {"appRequestNo": "req-1", "returnCode": "000000"},
+            }
+        )
+        assert resp.payload.return_code == "000000"
+        assert resp.payload.app_request_no == "req-1"
+
+    def test_response_degrades_without_payload(self) -> None:
+        """A missing payload (e.g. rejected/malformed) degrades to None, no raise."""
+        assert (
+            RemoteClimateControlResponseModel(
+                **{"status": {"messages": []}}
+            ).payload
+            is None
+        )

--- a/tests/unit_tests/test_set_climate.py
+++ b/tests/unit_tests/test_set_climate.py
@@ -1,0 +1,42 @@
+"""Unit test for Vehicle.set_climate delegation to Api.send_climate_control_command.
+
+The public Vehicle.set_climate wrapper exists so consumers actuate climate without
+reaching into the private ``vehicle._api``. It is a thin pass-through: it forwards the
+vehicle's VIN and the V2 request body and returns the parsed acknowledgement.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pytoyoda.models.endpoints.climate import (
+    RemoteClimateControlResponseModel,
+    V2RemoteClimateControlRequestModel,
+)
+from pytoyoda.models.vehicle import Vehicle
+
+VIN = "Random0815"
+
+
+@pytest.mark.asyncio
+async def test_vehicle_set_climate_delegates_to_api() -> None:
+    """Vehicle.set_climate() forwards vin + request to send_climate_control_command."""
+    api = AsyncMock()
+    api.send_climate_control_command.return_value = RemoteClimateControlResponseModel(
+        status={"messages": []}, payload={"returnCode": "000000"}
+    )
+
+    vehicle = Vehicle.__new__(Vehicle)
+    vehicle._api = api  # noqa: SLF001
+    vehicle._vehicle_info = type(  # type: ignore[attr-defined]
+        "_Stub", (), {"vin": VIN}
+    )()
+
+    request = V2RemoteClimateControlRequestModel(command="stop")
+    result = await vehicle.set_climate(request)
+
+    api.send_climate_control_command.assert_called_once_with(VIN, request)
+    assert isinstance(result, RemoteClimateControlResponseModel)
+    assert result.payload.return_code == "000000"


### PR DESCRIPTION
## What

Migrate **climate actuation** off the retired `/v1/global/remote/*` family to the unified `POST /v2/remote/climate-control`. This replaces the old two-call model (settings-`PUT` + control-`POST`) with a single request that carries the command plus the full desired state, and adds a public `Vehicle.set_climate()` entry point.

Stacked on #269 (climate reads); completes the climate half of #267. **Read side is #269; this is the write side.**

## Why

The old actuation routes are behind the same AWS SigV4/IAM authorizer as the rest of `/v1/global/remote/*` — plain-Bearer clients get `403 APIGW-403 / IncompleteSignatureException` (full root-cause evidence in #268). The current MyToyota EU 2.23.1 app drives climate through a single `POST /v2/remote/climate-control` on the plain-Bearer host:

- `start` carries `temperature` + `heatingOptions` + `seatOptions` + `saveSettings`.
- `stop` is just `{"command": "stop"}`.
- Acknowledgement is `payload.returnCode == "000000"`; the actual on/off state is confirmed via the climate-status read (#269).

The separate settings-`PUT` no longer exists in the app — settings are persisted via `saveSettings` on the same `start` call.

## Changes

- **const:** `VEHICLE_CLIMATE_CONTROL_ENDPOINT` → `/v2/remote/climate-control`. Removes the orphaned `VEHICLE_CLIMATE_SETTINGS_WRITE_ENDPOINT` that #269 introduced to hold the legacy write route.
- **models/endpoints/climate:** new `V2RemoteClimateControlRequestModel` (command + temperature + heating/seat options + `saveSettings`) and `RemoteClimateControlResponseModel` (`appRequestNo` + `returnCode`). **Removes the now-unused legacy write bodies** `ClimateSettingsRequestModel`, `ClimateControlModel`, `ACOperations`, `ACParameters`, `RemoteHVACModel` — nothing constructs them once the settings-PUT/control-POST paths are gone.
- **api:** `send_climate_control_command` takes the V2 request and returns the V2 response. `update_climate_settings` is **removed** (its route is retired and its function is subsumed by `start` + `saveSettings`).
- **models/vehicle:** new public `Vehicle.set_climate(request)` — a thin wrapper over `send_climate_control_command` so consumers actuate climate without reaching into the private `_api`. Matches the existing `refresh_status`/`refresh_climate_status` delegation pattern.
- **tests:** V2 request/response coverage in `test_models/test_climate.py`; `Vehicle.set_climate` delegation test.

## ⚠️ Breaking changes

- **`Api.update_climate_settings` is removed.** Callers move to `Vehicle.set_climate(...)` / `Api.send_climate_control_command(...)` with a `start` request (settings persist via `save_settings=True`).
- **`Api.send_climate_control_command` signature changed** — now takes `V2RemoteClimateControlRequestModel` and returns `RemoteClimateControlResponseModel` (was `ClimateControlModel` → `StatusModel`).
- The legacy write-body models listed above are removed from `pytoyoda.models.endpoints.climate`.

## Scope

| function | before | after | status |
|---|---|---|---|
| climate settings write | `PUT /v1/global/remote/climate-settings` (403) | folded into `start` + `saveSettings` | ✅ removed |
| climate control | `POST /v1/global/remote/climate-control` (403) | `POST /v2/remote/climate-control` | ✅ this PR |
| climate reads / wake | — | `/v1/vehicle/climate-*` | #269 |

## Verification

- Unit suite green (137 passed); `ruff check`/`format` clean on the package.
- **Live:** deployed via the integration wheel to a running HA install driving a Corolla TS. `start` (temperature + defroster) and `stop` through `send_climate_control_command` both return `payload.returnCode "000000"`, and the migrated climate-status read (#269) reflects the resulting on/off state on the next poll.
- On-state request/response shapes are sized from the decompiled app contract (`V2RemoteClimateControlRequest` / `RemoteClimateControlResponse`); every field is optional so an unexpected shape degrades to `None` rather than raising.

## Dependencies

**Requires #269 — do not merge before it.** This branch is stacked on `fix/migrate-climate-endpoints`; until #269 lands, this PR's diff also shows #269's commits. The GitHub base is `main` because upstream PRs can't target a fork branch.

> `pre-commit.ci` will show the pre-existing `TC003` on `controller.py` (`import ssl`) — already red on `main`, unrelated to this PR.

---

### The #267 migration, at a glance

Toyota fenced the whole `/v1/global/remote/*` family behind AWS SigV4 (→ `APIGW-403`); this series moves each surface onto the plain-Bearer routes the live MyToyota EU app (2.23.1) uses. **Four PRs, two independent chains:**

| PR | surface | route move | stacked on | breaking? |
|----|---------|-----------|-----------|-----------|
| #268 | status read | `…/remote/status` → `/v1/vehicle/status` | — | no |
| #270 | status wake | `POST …/remote/refresh-status` → `POST /v1/remote/status` | #268 | no |
| #269 | climate reads | `…/remote/climate-*` → `/v1/vehicle/climate-*` | — | yes ¹ |
| #271 | climate actuation | settings-PUT + control-POST → `POST /v2/remote/climate-control` | #269 | yes ² |

Suggested merge order: **#268 → #270** and **#269 → #271**; the two chains are independent and don't touch each other's files. Remote commands (lock/unlock/…) on `/v1/global/remote/command` are **not affected** — still plain Bearer, verified working.

¹ #269 reshapes the `ClimateStatus`/`ClimateSettings` accessors. ² #271 removes `update_climate_settings`. Both are detailed in their own PRs.
