### PR TITLE
fix(vehicle_guid): default remoteDisplay to None so vehicles still parse

### DIFF
--- a/pytoyoda/models/endpoints/vehicle_guid.py
+++ b/pytoyoda/models/endpoints/vehicle_guid.py
@@ -454,7 +454,7 @@ class VehicleGuidModel(CustomEndpointBaseModel):
     primary_subscriber: bool | None = Field(alias="primarySubscriber")
     region: str | None
     registration_number: str | None = Field(alias="registrationNumber")
-    remote_display: Any | None = Field(alias="remoteDisplay")
+    remote_display: Any | None = Field(alias="remoteDisplay", default=None)
     remote_service_capabilities: _RemoteServiceCapabilitiesModel | None = Field(
         alias="remoteServiceCapabilities"
     )

--- a/tests/unit_tests/test_models/test_vehicle_guid.py
+++ b/tests/unit_tests/test_models/test_vehicle_guid.py
@@ -1,0 +1,30 @@
+"""Tests for the vehicle_guid endpoint models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pytoyoda.models.endpoints.vehicle_guid import VehiclesResponseModel
+
+DATA_FILE = Path(__file__).parents[1] / "data" / "v2_vehicleguid.json"
+
+
+def test_payload_parses_without_remote_display() -> None:
+    """Regression for #277: 'remoteDisplay' is absent for some accounts.
+
+    Without default=None the required field failed validation and
+    ``invalid_to_none`` turned the whole payload list into None, so
+    ``get_vehicles()`` reported "No vehicles found".
+    """
+    with DATA_FILE.open(encoding="utf-8") as file:
+        response = json.load(file)
+    for vehicle in response["payload"]:
+        del vehicle["remoteDisplay"]
+
+    parsed = VehiclesResponseModel(**response)
+
+    assert parsed.payload is not None
+    assert len(parsed.payload) == len(response["payload"])
+    assert parsed.payload[0].vin == response["payload"][0]["vin"]
+    assert parsed.payload[0].remote_display is None


### PR DESCRIPTION
Fixes #277

### Problem

`GET /v2/vehicle/guid` does not return `remoteDisplay` for every account. `VehicleGuidModel` declared it as

```python
remote_display: Any | None = Field(alias="remoteDisplay")
```

which in pydantic v2 is a **required** field — no default. For such accounts the model raises `ValidationError`, and because `CustomEndpointBaseModel` wraps every field with `invalid_to_none`, the failure propagates up to `VehiclesResponseModel.payload` and the entire list silently becomes `None`. `Client.get_vehicles()` then logs "No vehicles found for this account" and returns `[]`, which leaves ha_toyota in a `ConfigEntryNotReady` retry loop.

### Fix

```python
remote_display: Any | None = Field(alias="remoteDisplay", default=None)
```

A missing `remoteDisplay` only degrades remote climate/status features — it should never hide the vehicle itself.

### Test

Adds `tests/unit_tests/test_models/test_vehicle_guid.py` — same shape as the `test_trips.py` regression for this bug class. It strips `remoteDisplay` from the captured `v2_vehicleguid.json` response and asserts the payload still parses (correct VIN, `remote_display is None`). The test fails on `main` and passes with this change; full unit suite is green (151 passed).

Note the test has to start from the captured fixture rather than a hand-built minimal dict: `VehicleGuidModel` still declares ~40 other fields without defaults, so a minimal payload fails validation for unrelated reasons. That is the same latent fragility, just not yet triggered in the wild.

### Not addressed here

The issue's second point stands: `invalid_to_none` dropping a whole list when a single item fails validation is its own bug class (see #259). Happy to follow up in a separate PR if maintainers want warning-and-skip semantics for list-typed fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)