### PR TITLE
fix(log_utils): walk nested dicts and lists in censor_all

### DIFF
--- a/pytoyoda/utils/log_utils.py
+++ b/pytoyoda/utils/log_utils.py
@@ -15,7 +15,6 @@ class SensitiveDataType(Enum):
 
     STRING = auto()
     FLOAT = auto()
-    NESTED = auto()
 
 
 # Default set of sensitive keys that should be censored
@@ -95,8 +94,6 @@ def get_sensitive_data_type(
             return SensitiveDataType.STRING
         if isinstance(value, float):
             return SensitiveDataType.FLOAT
-        if isinstance(value, (dict, list)):
-            return SensitiveDataType.NESTED
     return None
 
 
@@ -114,20 +111,19 @@ def censor_value(
         The censored value
 
     """
-    data_type = get_sensitive_data_type(value, key, to_censor)
+    # Sensitive fields usually sit under non-sensitive keys (vehicle_info,
+    # payload, ...), so containers are always walked regardless of their key.
+    if isinstance(value, dict):
+        return censor_all(value, to_censor)
+    if isinstance(value, list):
+        return [censor_value(item, key, to_censor) for item in value]
 
-    if data_type is None:
-        return value
+    data_type = get_sensitive_data_type(value, key, to_censor)
 
     if data_type == SensitiveDataType.STRING:
         return censor_string(value)
     if data_type == SensitiveDataType.FLOAT:
         return round(value)
-    if data_type == SensitiveDataType.NESTED:
-        if isinstance(value, dict):
-            return censor_all(value, to_censor)
-        if isinstance(value, list):
-            return [censor_value(item, key, to_censor) for item in value]
 
     return value
 

--- a/tests/unit_tests/test_utils/test_logs.py
+++ b/tests/unit_tests/test_utils/test_logs.py
@@ -73,6 +73,16 @@ def test_censor_value(value, key, to_censor, expected):  # noqa : D103
             {"password"},
             {"username": "user123", "password": None},
         ),
+        pytest.param(
+            {"vehicle_info": {"vin": "SB1ZB3AE50E022886", "latitude": 59.3293}},
+            {"vin", "latitude"},
+            {"vehicle_info": {"vin": "SB***************", "latitude": 59}},
+        ),
+        pytest.param(
+            {"payload": [{"vin": "SB1ZB3AE50E022886"}, {"vin": "JT123456789012345"}]},
+            {"vin"},
+            {"payload": [{"vin": "SB***************"}, {"vin": "JT***************"}]},
+        ),
     ],
 )
 def test_censor_all(dictionary, to_censor, expected):  # noqa : D103


### PR DESCRIPTION
censor_all only censored values whose own key was
  sensitive and never walked into dicts or lists under other keys, so Vehicle._dump_all() returned raw VIN and GPS. Containers are now always walked, only leaves are gated on the
  key. Adds tests for a nested dict and a list of dicts.
Closes #272