### PR TITLE
Add default value to remote_display field

### DIFF
--- a/pytoyoda/models/endpoints/vehicle_guid.py
+++ b/pytoyoda/models/endpoints/vehicle_guid.py
@@ -454,7 +454,7 @@ class VehicleGuidModel(CustomEndpointBaseModel):
     primary_subscriber: bool | None = Field(alias="primarySubscriber")
     region: str | None
     registration_number: str | None = Field(alias="registrationNumber")
-    remote_display: Any | None = Field(alias="remoteDisplay")
+    remote_display: Any | None = Field(alias="remoteDisplay", default=None)
     remote_service_capabilities: _RemoteServiceCapabilitiesModel | None = Field(
         alias="remoteServiceCapabilities"
     )


### PR DESCRIPTION
Older versions of Toyota don't deliver this value so one has to set a default value.