### PR TITLE
fix: make remote_display optional in VehicleGuid (Toyota removed field from API ~2026-09-02)

### DIFF
--- a/pytoyoda/models/endpoints/vehicle_guid.py
+++ b/pytoyoda/models/endpoints/vehicle_guid.py
@@ -454,7 +454,7 @@ class VehicleGuidModel(CustomEndpointBaseModel):
     primary_subscriber: bool | None = Field(alias="primarySubscriber")
     region: str | None
     registration_number: str | None = Field(alias="registrationNumber")
-    remote_display: Any | None = Field(alias="remoteDisplay")
+    remote_display: Any | None = Field(alias="remoteDisplay", default=None)
     remote_service_capabilities: _RemoteServiceCapabilitiesModel | None = Field(
         alias="remoteServiceCapabilities"
     )


### PR DESCRIPTION
## Summary

Single-line fix: mark `remote_display` as optional (`default=None`) in the `VehicleGuid` endpoint model.

## Problem

Between 2026-09-02 and 2026-09-03 Toyota removed the `remoteDisplay` field from the `/v2/vehicle/guid` endpoint response. Because the field is declared as required (no default), Pydantic validation now fails for every account, so `get_vehicles()` returns an empty list and clients built on top (the ha_toyota Home Assistant integration among others) report "No vehicles found for this account" while the vehicle is perfectly reachable.

User reports on the integration side: pytoyoda/ha_toyota#364, pytoyoda/ha_toyota#361, pytoyoda/ha_toyota#359, pytoyoda/ha_toyota#360 — all with the same signature since those dates.

## Fix

```python
remote_display: Any | None = Field(alias="remoteDisplay", default=None)
```

The field was already typed `Any | None`, so a missing key now simply validates to `None`. No other endpoint consumers reference this attribute.

## Verification

Patched the same one-liner directly in a Home Assistant OS venv (pytoyoda 5.2.0) on a two-vehicle Spanish MyT account:
- Before: integration failed setup, 0 vehicles returned
- After: both vehicles restored, full data flowing again (odometer, fuel, sensors) live for several hours

Fits cleanly on current `main`; last release (5.2.0, 2026-07-23) predates the API change, so a patch release would unbreak everyone.
